### PR TITLE
fix: enforce synchronous-only architecture in CLI commands

### DIFF
--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -15,7 +15,7 @@ export interface InitOptions {
  * @param options - Command options
  * @returns Exit code
  */
-export async function init(options: InitOptions = {}): Promise<number> {
+export function init(options: InitOptions = {}): number {
   try {
     const configPath = options.config || '.necromancer.json';
 

--- a/src/cli/commands/install.ts
+++ b/src/cli/commands/install.ts
@@ -1,4 +1,4 @@
-import { existsSync } from 'fs';
+import { existsSync, rmSync } from 'fs';
 import { parseConfigFile } from '../../core/config.js';
 import { readLockFile, writeLockFile } from '../../core/lockfile.js';
 import { installPlugin } from '../../core/installer.js';
@@ -59,7 +59,7 @@ function getLockFilePath(configPath: string): string {
  * @param options - Command options
  * @returns Exit code
  */
-export async function install(options: InstallOptions = {}): Promise<number> {
+export function install(options: InstallOptions = {}): number {
   try {
     // Enable verbose logging if requested
     if (options.verbose) {
@@ -142,9 +142,8 @@ export async function install(options: InstallOptions = {}): Promise<number> {
         logInfo(`\nRemoving ${orphanedPlugins.length} orphaned plugin(s)...`);
         for (const orphan of orphanedPlugins) {
           try {
-            const fs = await import('fs');
-            if (fs.existsSync(orphan.path)) {
-              fs.rmSync(orphan.path, { recursive: true, force: true });
+            if (existsSync(orphan.path)) {
+              rmSync(orphan.path, { recursive: true, force: true });
               logInfo(`✓ Removed ${orphan.name}`);
             }
           } catch (error) {

--- a/src/cli/commands/list.ts
+++ b/src/cli/commands/list.ts
@@ -55,7 +55,7 @@ function getLockFilePath(configPath: string): string {
  * @param options - Command options
  * @returns Exit code
  */
-export async function list(options: ListOptions = {}): Promise<number> {
+export function list(options: ListOptions = {}): number {
   try {
     if (options.verbose) {
       setVerbose(true);

--- a/src/cli/commands/update.ts
+++ b/src/cli/commands/update.ts
@@ -13,7 +13,7 @@ export interface UpdateOptions extends InstallOptions {
  * @param options - Command options
  * @returns Exit code
  */
-export async function update(options: UpdateOptions = {}): Promise<number> {
+export function update(options: UpdateOptions = {}): number {
   // If specific plugins are requested, we would filter here
   // For now, update is the same as install (both handle updates intelligently)
   // The filtering by plugin name can be added as an enhancement

--- a/src/cli/commands/verify.ts
+++ b/src/cli/commands/verify.ts
@@ -55,7 +55,7 @@ function getLockFilePath(configPath: string): string {
  * @param options - Command options
  * @returns Exit code (0 = all verified, 2 = issues found)
  */
-export async function verify(options: VerifyOptions = {}): Promise<number> {
+export function verify(options: VerifyOptions = {}): number {
   try {
     const configPath = resolveConfigPath(options.config);
     const config = parseConfigFile(configPath);

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -109,7 +109,7 @@ function parseCliArgs(): { command: string; options: Record<string, unknown> } {
 /**
  * Main CLI entry point
  */
-async function main(): Promise<void> {
+function main(): void {
   const { command, options } = parseCliArgs();
 
   let exitCode: number;
@@ -117,22 +117,22 @@ async function main(): Promise<void> {
   try {
     switch (command) {
       case 'init':
-        exitCode = await init(options);
+        exitCode = init(options);
         break;
       case 'install':
-        exitCode = await install(options);
+        exitCode = install(options);
         break;
       case 'update':
-        exitCode = await update(options);
+        exitCode = update(options);
         break;
       case 'list':
-        exitCode = await list(options);
+        exitCode = list(options);
         break;
       case 'verify':
-        exitCode = await verify(options);
+        exitCode = verify(options);
         break;
       case 'clean':
-        exitCode = await clean(options);
+        exitCode = clean(options);
         break;
       default:
         console.error(`Error: Command "${command}" not implemented`);
@@ -147,7 +147,4 @@ async function main(): Promise<void> {
 }
 
 // Run CLI
-main().catch(error => {
-  console.error(`Fatal error: ${error.message}`);
-  process.exit(3);
-});
+main();


### PR DESCRIPTION
## Summary

Removes all `async/await` usage from CLI commands to enforce the constitutional requirement of **synchronous-only architecture**.

## Changes

- ✅ Converted all CLI command functions from `async` → synchronous
- ✅ Replaced `await import('fs')` with direct `fs` imports in install.ts
- ✅ Implemented synchronous prompt using `readSync` in clean.ts (removed readline)
- ✅ Removed `async/await` from main CLI entry point (index.ts)
- ✅ All 152 tests passing

## Files Modified

- `src/cli/commands/clean.ts` - Synchronous prompt implementation
- `src/cli/commands/init.ts` - Removed async
- `src/cli/commands/install.ts` - Removed async + dynamic import
- `src/cli/commands/list.ts` - Removed async
- `src/cli/commands/update.ts` - Removed async
- `src/cli/commands/verify.ts` - Removed async
- `src/cli/index.ts` - Removed async from main() and switch statement

## Test Plan

- [x] Build succeeds: `npm run build`
- [x] All tests pass: `npm test` (152/152 ✓)
- [x] init command works correctly
- [x] list command works correctly
- [x] No async/await usage remains in CLI codebase

## Constitutional Compliance

This PR enforces the project's core architectural principle:

> **Synchronous-only architecture** - No async/await, Promises, or callbacks

All CLI operations now use synchronous Node.js APIs (`execSync`, `readFileSync`, `writeFileSync`, `readSync`) as specified in CLAUDE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)