### PR TITLE
chore: bump version to 0.1.2

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -12,7 +12,8 @@
       "Bash(git commit:*)",
       "Bash(git push:*)",
       "Bash(gh pr create:*)",
-      "Bash(git tag:*)"
+      "Bash(git tag:*)",
+      "Bash(find:*)"
     ],
     "deny": [],
     "ask": []

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,31 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.2] - 2025-10-06
+
+### Changed
+- Updated installation guide in documentation.
+- Updated Claude command documentation.
+
+### Fixed
+- Enforced synchronous-only architecture in CLI commands to maintain constitutional principles.
+
+## [0.1.1] - 2025-10-05
+
+### Added
+- Initial release of Necromancer - Git commit-based plugin manager for Neovim.
+- Zero runtime dependencies - only Node.js built-ins.
+- Synchronous-only architecture with no async/await or Promises.
+- CLI commands: `install`, `update`, `list`, `clean`.
+- Commit hash versioning with 40-character SHA-1 validation.
+- TypeScript strict mode compilation to ES2020+ JavaScript.
+
+[unreleased]: https://github.com/sontixyou/necromancer.nvim/compare/v0.1.2...HEAD
+[0.1.2]: https://github.com/sontixyou/necromancer.nvim/compare/v0.1.1...v0.1.2
+[0.1.1]: https://github.com/sontixyou/necromancer.nvim/releases/tag/v0.1.1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "necromancer.nvim",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Neovim plugin manager with commit-based versioning",
   "type": "module",
   "main": "./dist/cli/index.js",


### PR DESCRIPTION
## Summary
- Bump version from 0.1.1 to 0.1.2 in package.json
- Add CHANGELOG.md with version history following Keep a Changelog format
- Update Claude Code settings to allow find command

## Test plan
- [ ] Verify package.json version is 0.1.2
- [ ] Review CHANGELOG.md for accuracy and proper formatting
- [ ] Ensure all links in CHANGELOG.md are correct
- [ ] Verify no breaking changes introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)