### PR TITLE
chore: disable source maps and declaration maps

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,9 +11,9 @@
     /* Emit */
     "outDir": "./dist",
     "rootDir": "./src",
-    "sourceMap": true,
+    "sourceMap": false,
     "declaration": true,
-    "declarationMap": true,
+    "declarationMap": false,
 
     /* Interop Constraints */
     "esModuleInterop": true,


### PR DESCRIPTION
## Summary
- Disable `sourceMap` compiler option in tsconfig.json
- Disable `declarationMap` compiler option in tsconfig.json
- Reduces build output size and simplifies distribution package

## Test plan
- [ ] Run `npm run build` to verify successful compilation
- [ ] Verify dist output doesn't contain .map files
- [ ] Verify plugin functionality is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)