### PR TITLE
feat(lua): add autofetch on startup for necromancer self-update check

### DIFF
--- a/lua/necromancer/core/autofetch.lua
+++ b/lua/necromancer/core/autofetch.lua
@@ -1,0 +1,148 @@
+local M = {}
+
+---Normalize autofetch options
+---@param opts any User-provided options (boolean or table)
+---@return table Normalized options
+function M.normalize_opts(opts)
+  local defaults = {
+    enabled = true,
+    notify_updates = true,
+    quiet = false,
+  }
+
+  if opts == nil or opts == true then
+    return defaults
+  end
+
+  if opts == false then
+    defaults.enabled = false
+    return defaults
+  end
+
+  if type(opts) == "table" then
+    return {
+      enabled = opts.enabled ~= false,
+      notify_updates = opts.notify_updates ~= false,
+      quiet = opts.quiet == true,
+    }
+  end
+
+  return defaults
+end
+
+---Check if a directory is a git repository
+---@param path string Directory path
+---@return boolean
+local function is_git_repo(path)
+  local git_dir = path .. "/.git"
+  return vim.fn.isdirectory(git_dir) == 1 or vim.fn.filereadable(git_dir) == 1
+end
+
+---Get current HEAD commit hash
+---@param path string Repository path
+---@return string|nil
+local function get_head_commit(path)
+  local result = vim.fn.systemlist({ "git", "-C", path, "rev-parse", "HEAD" })
+  if vim.v.shell_error ~= 0 then
+    return nil
+  end
+  return result[1]
+end
+
+---Get remote tracking branch commit hash
+---@param path string Repository path
+---@return string|nil
+local function get_remote_commit(path)
+  local result = vim.fn.systemlist({ "git", "-C", path, "rev-parse", "@{upstream}" })
+  if vim.v.shell_error ~= 0 then
+    return nil
+  end
+  return result[1]
+end
+
+---Start autofetch process
+---@param opts? table Options from setup()
+function M.start(opts)
+  local normalized = M.normalize_opts(opts)
+
+  if not normalized.enabled then
+    return
+  end
+
+  local paths = require("necromancer.utils.paths")
+  local necromancer_path = paths.get_necromancer_path()
+
+  if not necromancer_path then
+    if not normalized.quiet then
+      vim.notify("[necromancer] Could not determine plugin path", vim.log.levels.DEBUG)
+    end
+    return
+  end
+
+  M.autofetch(necromancer_path, normalized)
+end
+
+---Execute autofetch asynchronously
+---@param path string Path to necromancer.nvim
+---@param opts table Normalized options
+function M.autofetch(path, opts)
+  if not is_git_repo(path) then
+    if not opts.quiet then
+      vim.notify("[necromancer] Not a git repository: " .. path, vim.log.levels.DEBUG)
+    end
+    return
+  end
+
+  -- Capture current HEAD before fetch
+  local head_before = get_head_commit(path)
+  if not head_before then
+    if not opts.quiet then
+      vim.notify("[necromancer] Could not get current HEAD", vim.log.levels.DEBUG)
+    end
+    return
+  end
+
+  -- Run git fetch asynchronously
+  local cmd = { "git", "-C", path, "fetch", "--quiet", "--all" }
+
+  vim.fn.jobstart(cmd, {
+    on_exit = function(_, exit_code)
+      if exit_code ~= 0 then
+        if not opts.quiet then
+          vim.notify("[necromancer] git fetch failed", vim.log.levels.DEBUG)
+        end
+        return
+      end
+
+      if opts.notify_updates then
+        M._check_updates(path, head_before, opts)
+      end
+    end,
+  })
+end
+
+---Check for updates after fetch and notify user
+---@param path string Repository path
+---@param head_before string HEAD commit before fetch
+---@param opts table Normalized options
+function M._check_updates(path, head_before, opts)
+  local remote_commit = get_remote_commit(path)
+
+  if not remote_commit then
+    if not opts.quiet then
+      vim.notify("[necromancer] Could not get remote commit", vim.log.levels.DEBUG)
+    end
+    return
+  end
+
+  if remote_commit ~= head_before then
+    vim.schedule(function()
+      vim.notify(
+        "[necromancer] Updates available! Run :Necromancer self-update to update.",
+        vim.log.levels.INFO
+      )
+    end)
+  end
+end
+
+return M

--- a/lua/necromancer/init.lua
+++ b/lua/necromancer/init.lua
@@ -6,6 +6,10 @@ M._VERSION = "2.0.0"
 ---@param opts? table Optional configuration
 ---  - config_path: string|nil - Custom path to config file
 ---  - install_dir: string|nil - Custom plugin installation directory
+---  - autofetch: boolean|table|nil - Auto-fetch necromancer updates on startup
+---    - enabled: boolean (default: true) - Enable/disable autofetch
+---    - notify_updates: boolean (default: true) - Show notification when updates are available
+---    - quiet: boolean (default: false) - Suppress debug messages
 function M.setup(opts)
   opts = opts or {}
 
@@ -33,6 +37,10 @@ function M.setup(opts)
   -- Register :Necromancer command
   local commands = require("necromancer.commands")
   commands.setup()
+
+  -- Start autofetch for necromancer itself
+  local autofetch = require("necromancer.core.autofetch")
+  autofetch.start(opts.autofetch)
 end
 
 return M

--- a/lua/necromancer/utils/paths.lua
+++ b/lua/necromancer/utils/paths.lua
@@ -70,6 +70,34 @@ function M.resolve_config_path(custom_path)
   return nil
 end
 
+---Get necromancer.nvim installation path
+---Uses debug.getinfo to determine the source file location
+---@return string|nil path Path to necromancer.nvim root directory, or nil if not found
+function M.get_necromancer_path()
+  -- Get the source path of this module
+  local info = debug.getinfo(1, "S")
+  if not info or not info.source then
+    return nil
+  end
+
+  -- Remove the leading @ from source path
+  local source = info.source
+  if source:sub(1, 1) == "@" then
+    source = source:sub(2)
+  end
+
+  -- This file is at lua/necromancer/utils/paths.lua
+  -- We need to go up 4 levels to get the plugin root
+  local path = vim.fn.fnamemodify(source, ":h:h:h:h")
+
+  -- Verify this is a valid directory
+  if vim.fn.isdirectory(path) == 1 then
+    return path
+  end
+
+  return nil
+end
+
 ---Get lock file path from config file path
 ---@param config_path string
 ---@return string

--- a/tests/necromancer/core/autofetch_spec.lua
+++ b/tests/necromancer/core/autofetch_spec.lua
@@ -1,0 +1,109 @@
+local autofetch = require("necromancer.core.autofetch")
+
+describe("autofetch", function()
+  describe("normalize_opts", function()
+    it("returns defaults when opts is nil", function()
+      local result = autofetch.normalize_opts(nil)
+      assert.equals(true, result.enabled)
+      assert.equals(true, result.notify_updates)
+      assert.equals(false, result.quiet)
+    end)
+
+    it("returns defaults when opts is true", function()
+      local result = autofetch.normalize_opts(true)
+      assert.equals(true, result.enabled)
+      assert.equals(true, result.notify_updates)
+      assert.equals(false, result.quiet)
+    end)
+
+    it("disables when opts is false", function()
+      local result = autofetch.normalize_opts(false)
+      assert.equals(false, result.enabled)
+      assert.equals(true, result.notify_updates)
+      assert.equals(false, result.quiet)
+    end)
+
+    it("uses table options when provided", function()
+      local result = autofetch.normalize_opts({
+        enabled = true,
+        notify_updates = false,
+        quiet = true,
+      })
+      assert.equals(true, result.enabled)
+      assert.equals(false, result.notify_updates)
+      assert.equals(true, result.quiet)
+    end)
+
+    it("defaults enabled to true when not specified in table", function()
+      local result = autofetch.normalize_opts({
+        quiet = true,
+      })
+      assert.equals(true, result.enabled)
+    end)
+
+    it("defaults notify_updates to true when not specified in table", function()
+      local result = autofetch.normalize_opts({
+        enabled = true,
+      })
+      assert.equals(true, result.notify_updates)
+    end)
+
+    it("defaults quiet to false when not specified in table", function()
+      local result = autofetch.normalize_opts({
+        enabled = true,
+      })
+      assert.equals(false, result.quiet)
+    end)
+
+    it("handles enabled=false in table", function()
+      local result = autofetch.normalize_opts({
+        enabled = false,
+      })
+      assert.equals(false, result.enabled)
+    end)
+  end)
+
+  describe("autofetch", function()
+    it("does not error on non-git directory", function()
+      local tmp_dir = vim.fn.tempname()
+      vim.fn.mkdir(tmp_dir, "p")
+
+      -- Should not throw an error
+      local ok, err = pcall(function()
+        autofetch.autofetch(tmp_dir, { enabled = true, notify_updates = true, quiet = true })
+      end)
+
+      vim.fn.delete(tmp_dir, "rf")
+      assert.is_true(ok, "Should not error: " .. tostring(err))
+    end)
+
+    it("does not error on non-existent directory", function()
+      local non_existent = "/non/existent/path/12345"
+
+      -- Should not throw an error
+      local ok, err = pcall(function()
+        autofetch.autofetch(non_existent, { enabled = true, notify_updates = true, quiet = true })
+      end)
+
+      assert.is_true(ok, "Should not error: " .. tostring(err))
+    end)
+  end)
+
+  describe("start", function()
+    it("does not error when disabled", function()
+      local ok, err = pcall(function()
+        autofetch.start(false)
+      end)
+      assert.is_true(ok, "Should not error: " .. tostring(err))
+    end)
+
+    it("does not error with default options", function()
+      -- Note: This may trigger actual fetch if running in a git repo
+      -- Using quiet mode to suppress any debug messages
+      local ok, err = pcall(function()
+        autofetch.start({ quiet = true })
+      end)
+      assert.is_true(ok, "Should not error: " .. tostring(err))
+    end)
+  end)
+end)

--- a/tests/necromancer/utils/paths_spec.lua
+++ b/tests/necromancer/utils/paths_spec.lua
@@ -85,6 +85,25 @@ describe("paths", function()
     end)
   end)
 
+  describe("get_necromancer_path", function()
+    it("returns a valid directory path", function()
+      local result = paths.get_necromancer_path()
+      -- May be nil in some test environments, but if not nil should be a directory
+      if result then
+        assert.equals(1, vim.fn.isdirectory(result))
+      end
+    end)
+
+    it("returns path that contains lua/necromancer subdirectory", function()
+      local result = paths.get_necromancer_path()
+      if result then
+        -- The returned path should have lua/necromancer subdirectory
+        local lua_path = result .. "/lua/necromancer"
+        assert.equals(1, vim.fn.isdirectory(lua_path))
+      end
+    end)
+  end)
+
   describe("get_lock_file_path", function()
     it("converts .necromancer.json to .necromancer.lock", function()
       local result = paths.get_lock_file_path(".necromancer.json")


### PR DESCRIPTION
## Summary
- Neovim起動時にnecromancer.nvim自体の更新を非同期でチェックする機能を追加
- `vim.fn.jobstart()`を使用して起動時間への影響を最小化
- 更新がある場合はユーザーに通知

## Changes
- `lua/necromancer/utils/paths.lua`: `get_necromancer_path()` 追加
- `lua/necromancer/core/autofetch.lua`: 新規作成（非同期fetch処理）
- `lua/necromancer/init.lua`: setup()にautofetchオプション追加
- テスト: 14件追加（autofetch 12件 + paths 2件）

## Usage
```lua
-- デフォルト有効
require("necromancer").setup()

-- 無効化
require("necromancer").setup({ autofetch = false })

-- 詳細設定
require("necromancer").setup({
  autofetch = {
    enabled = true,
    notify_updates = true,
    quiet = false,
  }
})
```

## Test plan
- [x] `make test-lua` で全autofetchテストが成功
- [ ] Neovimを起動して`:messages`で動作確認
- [ ] 更新がある場合に通知が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)