### PR TITLE
feat: add :Necromancer status command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ temp/
 
 # Test dependencies (Lua)
 test_deps/
+
+# Git worktrees
+.worktrees/

--- a/Makefile
+++ b/Makefile
@@ -8,13 +8,14 @@ test-ts:
 	npm test
 
 # Run Lua tests with plenary.nvim
+# Use NVIM_APPNAME to isolate from user config
 test-lua: test-deps
-	nvim --headless -u tests/minimal_init.lua -c "PlenaryBustedDirectory tests/necromancer/ {minimal_init = 'tests/minimal_init.lua', sequential = true}"
+	NVIM_APPNAME=necromancer-test nvim --headless -u tests/minimal_init.lua -c "PlenaryBustedDirectory tests/necromancer/ {minimal_init = 'tests/minimal_init.lua', sequential = true}"
 
 # Run a specific Lua test file
 # Usage: make test-file FILE=tests/necromancer/core/config_spec.lua
 test-file: test-deps
-	nvim --headless -u tests/minimal_init.lua -c "PlenaryBustedFile $(FILE)"
+	NVIM_APPNAME=necromancer-test nvim --headless -u tests/minimal_init.lua -c "PlenaryBustedFile $(FILE)"
 
 # Install test dependencies (plenary.nvim)
 test-deps:

--- a/docs/plans/2026-01-25-status-command-design.md
+++ b/docs/plans/2026-01-25-status-command-design.md
@@ -1,0 +1,143 @@
+# :Necromancer status コマンド設計
+
+## 概要
+
+プラグインごとの状態を確認するコマンド。各プラグインが「最新」「更新可能」「未インストール」「不整合」のどの状態かを表示する。
+
+## 要件
+
+- リモートの最新コミットも確認する（git fetch を実行）
+- status 実行時に毎回 fetch（シンプルな実装）
+- フローティングウィンドウで表示（既存の list コマンドと統一）
+
+## アーキテクチャ
+
+```
+:Necromancer status
+     ↓
+1. 設定ファイル読み込み (.necromancer.json)
+2. ロックファイル読み込み (.necromancer.lock)
+3. 各プラグインに対して:
+   a. インストール状態確認
+   b. git fetch 実行
+   c. 現在のコミットと設定を比較
+   d. リモート HEAD との比較
+4. ステータス一覧をフローティングウィンドウに表示
+```
+
+## ステータス種類
+
+| ステータス | 条件 |
+|-----------|------|
+| `up-to-date` | 設定のコミット = 実際のコミット（リモートも同じ、または確認失敗時） |
+| `outdated` | 設定のコミット ≠ 実際のコミット |
+| `update available` | 設定のコミット = 実際のコミット、かつリモート HEAD ≠ 設定のコミット |
+| `not installed` | プラグインディレクトリが存在しない |
+| `corrupted` | ディレクトリはあるが .git がない等 |
+| `fetch failed` | git fetch が失敗 |
+
+### ステータス判定優先度
+
+1. `not installed` - 最優先
+2. `corrupted` - ディレクトリはあるが .git がない等
+3. `outdated` - 設定と実際が不一致
+4. `update available` - リモートに新しいコミット
+5. `up-to-date` - 正常
+
+## 実装詳細
+
+### 変更ファイル
+
+**lua/necromancer/commands.lua**:
+```lua
+---Get status of a single plugin
+---@param plugin_def table Plugin definition from config
+---@param install_dir string Installation directory
+---@param lock table Lock file data
+---@return table status {name, state, current_commit, config_commit, remote_commit}
+local function get_plugin_status(plugin_def, install_dir, lock)
+
+---Show status of all configured plugins
+function M.cmd_status()
+```
+
+**lua/necromancer/core/git.lua**:
+```lua
+---Get remote HEAD commit (after fetch)
+---@param repo_path string Path to repository
+---@return string|nil commit Remote HEAD hash, or nil if failed
+function M.get_remote_head(repo_path)
+```
+
+### 依存モジュール
+
+- `config`: 設定ファイル読み込み
+- `lockfile`: ロックファイル読み込み
+- `git`: fetch, get_current_commit, get_remote_head
+- `paths`: パス解決
+
+## エラーハンドリング
+
+| ケース | 対応 |
+|--------|------|
+| 設定ファイルなし | エラー通知して終了 |
+| git fetch 失敗（ネットワークエラー等） | そのプラグインは `fetch failed` として表示、他は継続 |
+| リモート HEAD 取得失敗 | `update available` 判定をスキップ |
+| プラグインディレクトリ破損 | `corrupted` ステータスを表示 |
+
+## 進捗表示
+
+- fetch 実行中は `vim.notify` で進捗を表示
+- 例: `Fetching updates... (3/10)`
+
+## UI 仕様
+
+### フローティングウィンドウ
+
+- スタイル: `border = "rounded"`（既存の list と統一）
+- タイトル: ` Necromancer Status `
+- 幅: 70文字
+- 高さ: プラグイン数 + ヘッダー行、最大20行
+
+### 表示フォーマット
+
+```
+Plugin Status (fetched at 15:30:45):
+
+  ✓ plenary.nvim         up-to-date       @ a3e3bc82
+  ⬆ telescope.nvim       update available @ abc12345 → def67890
+  ✗ nvim-treesitter      not installed
+  ! nvim-cmp             outdated         @ 111aaaaa ≠ 222bbbbb
+  ? some-plugin          fetch failed
+
+Summary: 2 up-to-date, 1 update available, 1 outdated, 1 not installed
+```
+
+### アイコン
+
+| アイコン | ステータス | 色 |
+|---------|-----------|-----|
+| `✓` | up-to-date | 緑 |
+| `⬆` | update available | 青 |
+| `!` | outdated | 黄 |
+| `✗` | not installed | 赤 |
+| `?` | fetch failed | 灰 |
+
+### キーマップ
+
+- `q` / `<Esc>`: ウィンドウを閉じる
+
+## テスト計画
+
+### tests/necromancer/commands_spec.lua
+
+1. 設定ファイルがない場合 - エラーメッセージが表示されること
+2. プラグインが未インストールの場合 - `not installed` ステータスが返ること
+3. プラグインが最新の場合 - `up-to-date` が返ること
+4. プラグインが outdated の場合 - `outdated` が返ること
+5. get_plugin_status 関数の単体テスト
+
+### tests/necromancer/core/git_spec.lua
+
+6. get_remote_head の正常系 - origin/HEAD が取得できること
+7. get_remote_head の異常系 - リモートがない場合に nil を返すこと

--- a/docs/plans/2026-01-25-status-command-implementation.md
+++ b/docs/plans/2026-01-25-status-command-implementation.md
@@ -1,0 +1,596 @@
+# :Necromancer status コマンド実装計画
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** プラグインごとの状態（up-to-date, outdated, update available, not installed）を表示する status コマンドを実装する
+
+**Architecture:** git.lua に get_remote_head 関数を追加し、commands.lua に get_plugin_status ヘルパーと cmd_status コマンドを実装。フローティングウィンドウで表示。
+
+**Tech Stack:** Lua, Neovim API, plenary.nvim (テスト)
+
+---
+
+## Task 1: git.get_remote_head 関数の追加
+
+**Files:**
+- Modify: `lua/necromancer/core/git.lua:91` (return M の前)
+- Test: `tests/necromancer/core/git_spec.lua`
+
+**Step 1: Write the failing test**
+
+`tests/necromancer/core/git_spec.lua` の末尾（`end)` の前）に追加:
+
+```lua
+  describe("get_remote_head", function()
+    it("returns remote HEAD commit hash", function()
+      -- Clone to get a repo with remote
+      local clone_path = test_dir .. "/cloned"
+      git.clone(test_repo, clone_path)
+
+      local remote_head = git.get_remote_head(clone_path)
+      assert.is_not_nil(remote_head)
+      assert.equals(40, #remote_head)
+      assert.is_true(remote_head:match("^[a-f0-9]+$") ~= nil)
+    end)
+
+    it("returns nil when remote does not exist", function()
+      -- test_repo has no remote
+      local remote_head = git.get_remote_head(test_repo)
+      assert.is_nil(remote_head)
+    end)
+  end)
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `make test-file FILE=tests/necromancer/core/git_spec.lua`
+
+Expected: FAIL with "attempt to call field 'get_remote_head' (a nil value)"
+
+**Step 3: Write minimal implementation**
+
+`lua/necromancer/core/git.lua` の `return M` の前に追加:
+
+```lua
+---Get remote HEAD commit hash
+---@param repo_path string Path to repository
+---@return string|nil commit 40-character hash, or nil if no remote
+function M.get_remote_head(repo_path)
+  -- Try to get remote HEAD (origin/HEAD -> origin/main or origin/master)
+  local ok, result = pcall(function()
+    -- First try origin/HEAD
+    local head = git_exec({ "rev-parse", "origin/HEAD" }, repo_path)
+    return head
+  end)
+
+  if ok then
+    return result
+  end
+
+  -- Fallback: try origin/main, then origin/master
+  ok, result = pcall(function()
+    return git_exec({ "rev-parse", "origin/main" }, repo_path)
+  end)
+
+  if ok then
+    return result
+  end
+
+  ok, result = pcall(function()
+    return git_exec({ "rev-parse", "origin/master" }, repo_path)
+  end)
+
+  if ok then
+    return result
+  end
+
+  return nil
+end
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `make test-file FILE=tests/necromancer/core/git_spec.lua`
+
+Expected: PASS (7 tests)
+
+**Step 5: Commit**
+
+```bash
+git add lua/necromancer/core/git.lua tests/necromancer/core/git_spec.lua
+git commit -m "feat(git): add get_remote_head function for status command"
+```
+
+---
+
+## Task 2: get_plugin_status ヘルパー関数の追加
+
+**Files:**
+- Modify: `lua/necromancer/commands.lua` (find_plugin_by_name 関数の後)
+- Test: `tests/necromancer/commands_spec.lua`
+
+**Step 1: Write the failing test**
+
+`tests/necromancer/commands_spec.lua` に追加（describe("commands", function() 内の適切な場所）:
+
+```lua
+  describe("get_plugin_status", function()
+    local git = require("necromancer.core.git")
+    local installer = require("necromancer.core.installer")
+
+    it("returns 'not_installed' when plugin directory does not exist", function()
+      local plugin_def = {
+        name = "test-plugin",
+        repo = "https://github.com/test/test-plugin",
+        commit = "1234567890abcdef1234567890abcdef12345678",
+      }
+      local install_dir = test_dir .. "/plugins"
+      local lock = { plugins = {} }
+
+      local status = commands.get_plugin_status(plugin_def, install_dir, lock)
+
+      assert.equals("test-plugin", status.name)
+      assert.equals("not_installed", status.state)
+    end)
+
+    it("returns 'corrupted' when directory exists but is not a git repo", function()
+      local plugin_def = {
+        name = "test-plugin",
+        repo = "https://github.com/test/test-plugin",
+        commit = "1234567890abcdef1234567890abcdef12345678",
+      }
+      local install_dir = test_dir .. "/plugins"
+      local lock = { plugins = {} }
+
+      -- Create directory without .git
+      vim.fn.mkdir(install_dir .. "/test-plugin", "p")
+
+      local status = commands.get_plugin_status(plugin_def, install_dir, lock)
+
+      assert.equals("test-plugin", status.name)
+      assert.equals("corrupted", status.state)
+    end)
+
+    it("returns 'outdated' when current commit differs from config", function()
+      local plugin_def = {
+        name = "test-plugin",
+        repo = test_dir .. "/origin-repo",
+        commit = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      }
+      local install_dir = test_dir .. "/plugins"
+      local lock = { plugins = {} }
+
+      -- Create origin repo
+      local origin_repo = test_dir .. "/origin-repo"
+      vim.fn.mkdir(origin_repo, "p")
+      vim.fn.system({ "git", "-C", origin_repo, "init" })
+      vim.fn.system({ "git", "-C", origin_repo, "config", "user.email", "test@test.com" })
+      vim.fn.system({ "git", "-C", origin_repo, "config", "user.name", "Test" })
+      vim.fn.writefile({ "test" }, origin_repo .. "/file.txt")
+      vim.fn.system({ "git", "-C", origin_repo, "add", "." })
+      vim.fn.system({ "git", "-C", origin_repo, "commit", "-m", "initial" })
+
+      -- Clone to install dir
+      vim.fn.mkdir(install_dir, "p")
+      git.clone(origin_repo, install_dir .. "/test-plugin")
+
+      local status = commands.get_plugin_status(plugin_def, install_dir, lock)
+
+      assert.equals("test-plugin", status.name)
+      assert.equals("outdated", status.state)
+    end)
+
+    it("returns 'up_to_date' when current commit matches config", function()
+      local origin_repo = test_dir .. "/origin-repo"
+      vim.fn.mkdir(origin_repo, "p")
+      vim.fn.system({ "git", "-C", origin_repo, "init" })
+      vim.fn.system({ "git", "-C", origin_repo, "config", "user.email", "test@test.com" })
+      vim.fn.system({ "git", "-C", origin_repo, "config", "user.name", "Test" })
+      vim.fn.writefile({ "test" }, origin_repo .. "/file.txt")
+      vim.fn.system({ "git", "-C", origin_repo, "add", "." })
+      vim.fn.system({ "git", "-C", origin_repo, "commit", "-m", "initial" })
+
+      local commit = git.get_current_commit(origin_repo)
+
+      local plugin_def = {
+        name = "test-plugin",
+        repo = origin_repo,
+        commit = commit,
+      }
+      local install_dir = test_dir .. "/plugins"
+      local lock = { plugins = {} }
+
+      -- Clone to install dir
+      vim.fn.mkdir(install_dir, "p")
+      git.clone(origin_repo, install_dir .. "/test-plugin")
+
+      local status = commands.get_plugin_status(plugin_def, install_dir, lock)
+
+      assert.equals("test-plugin", status.name)
+      assert.equals("up_to_date", status.state)
+      assert.equals(commit, status.current_commit)
+    end)
+  end)
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `make test-file FILE=tests/necromancer/commands_spec.lua`
+
+Expected: FAIL with "attempt to call field 'get_plugin_status' (a nil value)"
+
+**Step 3: Write minimal implementation**
+
+`lua/necromancer/commands.lua` の `find_plugin_by_name` 関数の後に追加:
+
+```lua
+local git = require("necromancer.core.git")
+
+---Get status of a single plugin
+---@param plugin_def table Plugin definition from config
+---@param install_dir string Installation directory
+---@param lock table Lock file data (unused for now)
+---@return table status {name, state, current_commit, config_commit, remote_commit, error_msg}
+function M.get_plugin_status(plugin_def, install_dir, lock)
+  local plugin_path = paths.resolve_plugin_path(plugin_def.name, install_dir)
+  local result = {
+    name = plugin_def.name,
+    state = "unknown",
+    config_commit = plugin_def.commit,
+    current_commit = nil,
+    remote_commit = nil,
+    error_msg = nil,
+  }
+
+  -- Check if directory exists
+  if vim.fn.isdirectory(plugin_path) ~= 1 then
+    result.state = "not_installed"
+    return result
+  end
+
+  -- Check if it's a git repo
+  if vim.fn.isdirectory(plugin_path .. "/.git") ~= 1 then
+    result.state = "corrupted"
+    return result
+  end
+
+  -- Get current commit
+  local ok, current_commit = pcall(git.get_current_commit, plugin_path)
+  if not ok then
+    result.state = "corrupted"
+    result.error_msg = tostring(current_commit)
+    return result
+  end
+  result.current_commit = current_commit
+
+  -- Fetch and get remote HEAD
+  local fetch_ok = pcall(git.fetch, plugin_path)
+  if fetch_ok then
+    result.remote_commit = git.get_remote_head(plugin_path)
+  else
+    result.error_msg = "fetch_failed"
+  end
+
+  -- Determine state
+  if current_commit ~= plugin_def.commit then
+    result.state = "outdated"
+  elseif result.remote_commit and result.remote_commit ~= plugin_def.commit then
+    result.state = "update_available"
+  else
+    result.state = "up_to_date"
+  end
+
+  return result
+end
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `make test-file FILE=tests/necromancer/commands_spec.lua`
+
+Expected: PASS (12 tests)
+
+**Step 5: Commit**
+
+```bash
+git add lua/necromancer/commands.lua tests/necromancer/commands_spec.lua
+git commit -m "feat(commands): add get_plugin_status helper function"
+```
+
+---
+
+## Task 3: cmd_status コマンドの実装
+
+**Files:**
+- Modify: `lua/necromancer/commands.lua`
+- Test: `tests/necromancer/commands_spec.lua`
+
+**Step 1: Write the failing test**
+
+`tests/necromancer/commands_spec.lua` に追加:
+
+```lua
+  describe("cmd_status", function()
+    it("shows error when config file not found", function()
+      -- No config file exists
+      -- This should show an error but not crash
+      commands.cmd_status()
+      assert.is_true(true)
+    end)
+
+    it("opens floating window with status", function()
+      -- Create config with a plugin
+      local cfg = {
+        plugins = {
+          {
+            name = "plenary.nvim",
+            repo = "https://github.com/nvim-lua/plenary.nvim",
+            commit = "a3e3bc82a3f95c5ed0d7201546d5d2c19b20d683",
+          },
+        },
+      }
+      vim.fn.writefile({ vim.json.encode(cfg) }, ".necromancer.json")
+
+      -- Run status command
+      commands.cmd_status()
+
+      -- Find the floating window
+      local wins = vim.api.nvim_list_wins()
+      local found_float = false
+      for _, win in ipairs(wins) do
+        local win_config = vim.api.nvim_win_get_config(win)
+        if win_config.relative ~= "" then
+          found_float = true
+          vim.api.nvim_win_close(win, true)
+          break
+        end
+      end
+
+      assert.is_true(found_float, "Should open a floating window")
+    end)
+  end)
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `make test-file FILE=tests/necromancer/commands_spec.lua`
+
+Expected: FAIL with "attempt to call field 'cmd_status' (a nil value)"
+
+**Step 3: Write minimal implementation**
+
+`lua/necromancer/commands.lua` の `cmd_init` 関数の後に追加:
+
+```lua
+---Status icons and labels
+local STATUS_INFO = {
+  up_to_date = { icon = "✓", label = "up-to-date" },
+  update_available = { icon = "⬆", label = "update available" },
+  outdated = { icon = "!", label = "outdated" },
+  not_installed = { icon = "✗", label = "not installed" },
+  corrupted = { icon = "⚠", label = "corrupted" },
+  fetch_failed = { icon = "?", label = "fetch failed" },
+}
+
+---Show status of all configured plugins
+function M.cmd_status()
+  -- Find config file
+  local config_path = paths.resolve_config_path()
+  if not config_path then
+    vim.notify("Config file not found. Run :Necromancer init to create one.", vim.log.levels.ERROR)
+    return
+  end
+
+  -- Parse config
+  local ok, cfg = pcall(config.parse_config_file, config_path)
+  if not ok then
+    vim.notify("Failed to parse config: " .. tostring(cfg), vim.log.levels.ERROR)
+    return
+  end
+
+  -- Get install directory and lock file
+  local install_dir = paths.get_default_install_dir()
+  local lock_path = paths.get_lock_file_path(config_path)
+  local lock = lockfile.read(lock_path)
+
+  -- Get status for each plugin
+  local statuses = {}
+  local total = #cfg.plugins
+  for i, plugin_def in ipairs(cfg.plugins) do
+    vim.notify(string.format("Fetching updates... (%d/%d) %s", i, total, plugin_def.name), vim.log.levels.INFO)
+    local status = M.get_plugin_status(plugin_def, install_dir, lock)
+    table.insert(statuses, status)
+  end
+
+  -- Build output lines
+  local timestamp = os.date("%H:%M:%S")
+  local lines = { string.format("Plugin Status (fetched at %s):", timestamp), "" }
+
+  -- Track summary counts
+  local counts = {}
+  for _, status in ipairs(statuses) do
+    counts[status.state] = (counts[status.state] or 0) + 1
+  end
+
+  -- Find max plugin name length for alignment
+  local max_name_len = 0
+  for _, status in ipairs(statuses) do
+    max_name_len = math.max(max_name_len, #status.name)
+  end
+
+  -- Format each plugin line
+  for _, status in ipairs(statuses) do
+    local info = STATUS_INFO[status.state] or { icon = "?", label = status.state }
+    local name_padded = status.name .. string.rep(" ", max_name_len - #status.name)
+    local line
+
+    if status.state == "not_installed" then
+      line = string.format("  %s %s  %s", info.icon, name_padded, info.label)
+    elseif status.state == "corrupted" then
+      line = string.format("  %s %s  %s", info.icon, name_padded, info.label)
+    elseif status.state == "outdated" then
+      local short_current = status.current_commit and status.current_commit:sub(1, 8) or "????????"
+      local short_config = status.config_commit:sub(1, 8)
+      line = string.format("  %s %s  %-16s @ %s ≠ %s", info.icon, name_padded, info.label, short_current, short_config)
+    elseif status.state == "update_available" then
+      local short_current = status.current_commit:sub(1, 8)
+      local short_remote = status.remote_commit and status.remote_commit:sub(1, 8) or "????????"
+      line = string.format("  %s %s  %-16s @ %s → %s", info.icon, name_padded, info.label, short_current, short_remote)
+    else
+      local short_commit = status.current_commit and status.current_commit:sub(1, 8) or "????????"
+      line = string.format("  %s %s  %-16s @ %s", info.icon, name_padded, info.label, short_commit)
+    end
+
+    table.insert(lines, line)
+  end
+
+  -- Add summary
+  table.insert(lines, "")
+  local summary_parts = {}
+  for _, state in ipairs({ "up_to_date", "update_available", "outdated", "not_installed", "corrupted" }) do
+    if counts[state] and counts[state] > 0 then
+      local info = STATUS_INFO[state]
+      table.insert(summary_parts, string.format("%d %s", counts[state], info.label))
+    end
+  end
+  table.insert(lines, "Summary: " .. table.concat(summary_parts, ", "))
+
+  -- Show in floating window
+  local buf = vim.api.nvim_create_buf(false, true)
+  vim.api.nvim_buf_set_lines(buf, 0, -1, false, lines)
+  vim.api.nvim_set_option_value("modifiable", false, { buf = buf })
+  vim.api.nvim_set_option_value("buftype", "nofile", { buf = buf })
+  vim.api.nvim_set_option_value("filetype", "necromancer", { buf = buf })
+
+  -- Calculate window size
+  local width = 70
+  local height = math.min(#lines + 2, 20)
+  local row = math.floor((vim.o.lines - height) / 2)
+  local col = math.floor((vim.o.columns - width) / 2)
+
+  local win = vim.api.nvim_open_win(buf, true, {
+    relative = "editor",
+    width = width,
+    height = height,
+    row = row,
+    col = col,
+    style = "minimal",
+    border = "rounded",
+    title = " Necromancer Status ",
+    title_pos = "center",
+  })
+
+  -- Close on q or <Esc>
+  vim.keymap.set("n", "q", function()
+    vim.api.nvim_win_close(win, true)
+  end, { buffer = buf, nowait = true })
+  vim.keymap.set("n", "<Esc>", function()
+    vim.api.nvim_win_close(win, true)
+  end, { buffer = buf, nowait = true })
+end
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `make test-file FILE=tests/necromancer/commands_spec.lua`
+
+Expected: PASS (14 tests)
+
+**Step 5: Commit**
+
+```bash
+git add lua/necromancer/commands.lua tests/necromancer/commands_spec.lua
+git commit -m "feat(commands): add cmd_status for plugin status display"
+```
+
+---
+
+## Task 4: サブコマンドの登録
+
+**Files:**
+- Modify: `lua/necromancer/commands.lua` (get_subcommands と dispatch 関数)
+
+**Step 1: Update get_subcommands**
+
+`lua/necromancer/commands.lua` の `get_subcommands` 関数を更新:
+
+```lua
+---Get list of available subcommands
+---@return string[]
+local function get_subcommands()
+  return { "install", "list", "init", "status" }
+end
+```
+
+**Step 2: Update dispatch**
+
+`dispatch` 関数内の条件分岐に追加:
+
+```lua
+  elseif subcommand == "status" then
+    M.cmd_status()
+```
+
+**Step 3: Update usage message**
+
+`dispatch` 関数内の usage メッセージを更新:
+
+```lua
+  if not subcommand then
+    vim.notify("Usage: :Necromancer <install|list|init|status> [args]", vim.log.levels.ERROR)
+    return
+  end
+```
+
+また、unknown subcommand のメッセージも更新:
+
+```lua
+    vim.notify("Available commands: install, list, init, status", vim.log.levels.INFO)
+```
+
+**Step 4: Run all tests**
+
+Run: `make test-lua`
+
+Expected: All tests PASS
+
+**Step 5: Commit**
+
+```bash
+git add lua/necromancer/commands.lua
+git commit -m "feat(commands): register status subcommand"
+```
+
+---
+
+## Task 5: 全テスト実行と最終確認
+
+**Step 1: Run all tests**
+
+Run: `make test-lua`
+
+Expected: All tests PASS (at least 97 tests)
+
+**Step 2: Manual verification (optional)**
+
+Neovim で実際にコマンドを実行して確認:
+
+```vim
+:Necromancer status
+```
+
+**Step 3: Final commit (if any fixes needed)**
+
+もし修正が必要な場合のみコミット。
+
+---
+
+## Summary
+
+| Task | Description | Files |
+|------|-------------|-------|
+| 1 | git.get_remote_head 追加 | git.lua, git_spec.lua |
+| 2 | get_plugin_status ヘルパー追加 | commands.lua, commands_spec.lua |
+| 3 | cmd_status 実装 | commands.lua, commands_spec.lua |
+| 4 | サブコマンド登録 | commands.lua |
+| 5 | 全テスト実行 | - |

--- a/docs/plans/2026-01-25-update-command-design.md
+++ b/docs/plans/2026-01-25-update-command-design.md
@@ -1,0 +1,198 @@
+# :Necromancer update コマンド設計
+
+## 概要
+
+プラグインを設定ファイルで指定されたブランチの「1週間前のコミット」に更新するコマンド。安定性を重視し、最新の不安定なコミットを避ける設計。
+
+## コマンドインターフェース
+
+```
+:Necromancer update          # 全プラグインを更新
+:Necromancer update [name]   # 特定プラグインのみ更新
+```
+
+### 処理フロー
+
+1. 設定ファイル（`.necromancer.json`）を読み込み
+2. 対象プラグインごとに：
+   - `git fetch --all` でリモートから最新情報を取得
+   - 対象ブランチの1週間前コミットを特定
+   - 設定ファイルの `commit` フィールドを更新
+   - 該当コミットに checkout
+3. 成功したプラグインの情報で設定ファイルを上書き保存
+4. lockfile も更新
+
+### 出力例
+
+```
+Fetching telescope.nvim...
+Updated telescope.nvim: abc1234 → def5678 (branch: main, 7 days ago)
+Fetching plenary.nvim...
+plenary.nvim is already up to date
+Update complete: 1 updated, 1 skipped, 0 failed
+```
+
+## 設定ファイルのスキーマ拡張
+
+### 新しいフィールド `branch`（オプション）
+
+```json
+{
+  "plugins": [
+    {
+      "name": "telescope.nvim",
+      "repo": "https://github.com/nvim-telescope/telescope.nvim",
+      "commit": "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+      "branch": "main",
+      "dependencies": ["plenary.nvim"]
+    },
+    {
+      "name": "plenary.nvim",
+      "repo": "https://github.com/nvim-lua/plenary.nvim",
+      "commit": "b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3"
+    }
+  ]
+}
+```
+
+### ブランチ解決の優先順位
+
+1. `branch` フィールドが指定されていればそれを使用
+2. 未指定の場合、`git remote show origin` でデフォルトブランチを検出
+3. 検出失敗時は `main` → `master` の順でフォールバック
+
+### バリデーション追加（validator.lua）
+
+- ブランチ名は英数字、ハイフン、アンダースコア、スラッシュ、ドットのみ許可
+- パターン: `^[%w][%w%.%-_/]*$`
+
+## Git 操作
+
+### git.lua への新規関数追加
+
+```lua
+-- デフォルトブランチを検出
+M.get_default_branch(repo_path)
+-- git remote show origin | grep "HEAD branch" を解析
+-- 失敗時は main → master のフォールバック
+
+-- 指定ブランチの1週間前コミットを取得
+M.get_commit_before_date(repo_path, branch, days_ago)
+-- git log origin/{branch} --before="7 days ago" -1 --format="%H"
+-- 1週間前にコミットが存在しない場合は最古のコミットを返す
+```
+
+### コマンド実行例
+
+```bash
+# デフォルトブランチ検出
+git remote show origin | grep "HEAD branch"
+
+# 1週間前のコミット取得
+git log origin/main --before="7 days ago" -1 --format="%H"
+```
+
+### エッジケース処理
+
+- リポジトリが1週間以内に作成された場合 → 最古のコミットを使用
+- ブランチが存在しない場合 → GitError を発生
+- fetch 前にこの処理を行うと古い情報になるため、必ず fetch 後に実行
+
+## 設定ファイル更新処理
+
+### config.lua への新規関数追加
+
+```lua
+-- 設定ファイルを更新（特定プラグインのcommitを変更）
+M.update_plugin_commit(config_path, plugin_name, new_commit)
+
+-- 複数プラグインのcommitを一括更新
+M.update_plugins_commits(config_path, updates)
+-- updates = { {name = "telescope.nvim", commit = "abc123..."}, ... }
+```
+
+### 更新フロー
+
+1. 既存の設定ファイルを読み込み（JSON パース）
+2. 対象プラグインの `commit` フィールドを更新
+3. JSON として整形して書き戻し
+
+### 整形ルール
+
+- `vim.json.encode()` を使用
+- 読みやすさのためインデント付き（可能であれば）
+
+### 注意点
+
+- 元のファイルのコメントや書式は保持されない（JSON 仕様上の制限）
+- 更新前にバックアップは作成しない（git で管理されている前提）
+
+## update コマンド実装（commands.lua）
+
+### 新規関数 `cmd_update(args)`
+
+```lua
+function M.cmd_update(args)
+  -- 1. 設定ファイル読み込み
+  -- 2. 対象プラグイン決定（引数があれば単一、なければ全て）
+  -- 3. 各プラグインに対して:
+  --    a. fetch 実行
+  --    b. ブランチ解決（指定 or デフォルト検出）
+  --    c. 1週間前コミット取得
+  --    d. 現在のコミットと比較（同じならスキップ）
+  --    e. checkout 実行
+  --    f. 成功リストに追加
+  -- 4. 成功したプラグインで設定ファイル更新
+  -- 5. lockfile 更新
+  -- 6. 結果サマリー表示
+end
+```
+
+### dispatch と補完への追加
+
+- `get_subcommands()` に `"update"` 追加
+- `complete()` で `update` の第2引数にプラグイン名補完
+- `dispatch()` に `update` ケース追加
+
+### 依存関係の考慮
+
+- update 時も依存関係順でソート（dependencies.lua 使用）
+- 依存先が更新失敗した場合でも、依存元は独立して処理（スキップしない）
+
+## エラーハンドリング
+
+| エラー | 対応 |
+|--------|------|
+| fetch 失敗（ネットワークエラー） | 該当プラグインをスキップ、警告表示 |
+| ブランチが存在しない | 該当プラグインをスキップ、エラー表示 |
+| 1週間前コミットが見つからない | 最古のコミットを使用、情報表示 |
+| checkout 失敗 | 該当プラグインをスキップ、設定更新しない |
+| 設定ファイル書き込み失敗 | エラー表示、処理中断 |
+
+### 部分的失敗時の動作
+
+- 成功したプラグインのみ設定ファイルに反映
+- 失敗したプラグインは元の状態を維持
+
+## テスト
+
+### テストファイル
+
+- `tests/necromancer/core/git_spec.lua` に `get_default_branch`、`get_commit_before_date` のテスト追加
+- `tests/necromancer/commands_spec.lua` に `cmd_update` のテスト追加
+
+### テスト観点
+
+- 単一プラグイン更新
+- 全プラグイン更新
+- ブランチ指定あり/なし
+- 既に最新の場合のスキップ
+- 部分的失敗時の動作
+
+## 実装タスク
+
+1. `validator.lua`: ブランチ名バリデーション関数追加
+2. `git.lua`: `get_default_branch`、`get_commit_before_date` 関数追加
+3. `config.lua`: `update_plugin_commit`、`update_plugins_commits` 関数追加
+4. `commands.lua`: `cmd_update` 関数追加、dispatch/補完対応
+5. テスト追加

--- a/lua/necromancer/commands.lua
+++ b/lua/necromancer/commands.lua
@@ -235,6 +235,133 @@ function M.cmd_list()
   end, { buffer = buf, nowait = true })
 end
 
+---Status icons and labels
+local STATUS_INFO = {
+  up_to_date = { icon = "✓", label = "up-to-date" },
+  update_available = { icon = "⬆", label = "update available" },
+  outdated = { icon = "!", label = "outdated" },
+  not_installed = { icon = "✗", label = "not installed" },
+  corrupted = { icon = "⚠", label = "corrupted" },
+  fetch_failed = { icon = "?", label = "fetch failed" },
+}
+
+---Show status of all configured plugins
+function M.cmd_status()
+  -- Find config file
+  local config_path = paths.resolve_config_path()
+  if not config_path then
+    vim.notify("Config file not found. Run :Necromancer init to create one.", vim.log.levels.ERROR)
+    return
+  end
+
+  -- Parse config
+  local ok, cfg = pcall(config.parse_config_file, config_path)
+  if not ok then
+    vim.notify("Failed to parse config: " .. tostring(cfg), vim.log.levels.ERROR)
+    return
+  end
+
+  -- Get install directory and lock file
+  local install_dir = paths.get_default_install_dir()
+  local lock_path = paths.get_lock_file_path(config_path)
+  local lock = lockfile.read(lock_path)
+
+  -- Get status for each plugin
+  local statuses = {}
+  local total = #cfg.plugins
+  for i, plugin_def in ipairs(cfg.plugins) do
+    vim.notify(string.format("Fetching updates... (%d/%d) %s", i, total, plugin_def.name), vim.log.levels.INFO)
+    local status = M.get_plugin_status(plugin_def, install_dir, lock)
+    table.insert(statuses, status)
+  end
+
+  -- Build output lines
+  local timestamp = os.date("%H:%M:%S")
+  local lines = { string.format("Plugin Status (fetched at %s):", timestamp), "" }
+
+  -- Track summary counts
+  local counts = {}
+  for _, status in ipairs(statuses) do
+    counts[status.state] = (counts[status.state] or 0) + 1
+  end
+
+  -- Find max plugin name length for alignment
+  local max_name_len = 0
+  for _, status in ipairs(statuses) do
+    max_name_len = math.max(max_name_len, #status.name)
+  end
+
+  -- Format each plugin line
+  for _, status in ipairs(statuses) do
+    local info = STATUS_INFO[status.state] or { icon = "?", label = status.state }
+    local name_padded = status.name .. string.rep(" ", max_name_len - #status.name)
+    local line
+
+    if status.state == "not_installed" then
+      line = string.format("  %s %s  %s", info.icon, name_padded, info.label)
+    elseif status.state == "corrupted" then
+      line = string.format("  %s %s  %s", info.icon, name_padded, info.label)
+    elseif status.state == "outdated" then
+      local short_current = status.current_commit and status.current_commit:sub(1, 8) or "????????"
+      local short_config = status.config_commit:sub(1, 8)
+      line = string.format("  %s %s  %-16s @ %s ≠ %s", info.icon, name_padded, info.label, short_current, short_config)
+    elseif status.state == "update_available" then
+      local short_current = status.current_commit:sub(1, 8)
+      local short_remote = status.remote_commit and status.remote_commit:sub(1, 8) or "????????"
+      line = string.format("  %s %s  %-16s @ %s → %s", info.icon, name_padded, info.label, short_current, short_remote)
+    else
+      local short_commit = status.current_commit and status.current_commit:sub(1, 8) or "????????"
+      line = string.format("  %s %s  %-16s @ %s", info.icon, name_padded, info.label, short_commit)
+    end
+
+    table.insert(lines, line)
+  end
+
+  -- Add summary
+  table.insert(lines, "")
+  local summary_parts = {}
+  for _, state in ipairs({ "up_to_date", "update_available", "outdated", "not_installed", "corrupted" }) do
+    if counts[state] and counts[state] > 0 then
+      local info = STATUS_INFO[state]
+      table.insert(summary_parts, string.format("%d %s", counts[state], info.label))
+    end
+  end
+  table.insert(lines, "Summary: " .. table.concat(summary_parts, ", "))
+
+  -- Show in floating window
+  local buf = vim.api.nvim_create_buf(false, true)
+  vim.api.nvim_buf_set_lines(buf, 0, -1, false, lines)
+  vim.api.nvim_set_option_value("modifiable", false, { buf = buf })
+  vim.api.nvim_set_option_value("buftype", "nofile", { buf = buf })
+  vim.api.nvim_set_option_value("filetype", "necromancer", { buf = buf })
+
+  -- Calculate window size
+  local width = 70
+  local height = math.min(#lines + 2, 20)
+  local row = math.floor((vim.o.lines - height) / 2)
+  local col = math.floor((vim.o.columns - width) / 2)
+
+  local win = vim.api.nvim_open_win(buf, true, {
+    relative = "editor",
+    width = width,
+    height = height,
+    row = row,
+    col = col,
+    style = "minimal",
+    border = "rounded",
+    title = " Necromancer Status ",
+    title_pos = "center",
+  })
+
+  -- Close on q or <Esc>
+  vim.keymap.set("n", "q", function()
+    vim.api.nvim_win_close(win, true)
+  end, { buffer = buf, nowait = true })
+  vim.keymap.set("n", "<Esc>", function()
+    vim.api.nvim_win_close(win, true)
+  end, { buffer = buf, nowait = true })
+end
+
 ---Generate a new .necromancer.json config file
 function M.cmd_init()
   local config_path = ".necromancer.json"
@@ -265,7 +392,7 @@ end
 ---Get list of available subcommands
 ---@return string[]
 local function get_subcommands()
-  return { "install", "list", "init" }
+  return { "install", "list", "status", "init" }
 end
 
 ---Get completions for :Necromancer command
@@ -316,7 +443,7 @@ local function dispatch(opts)
   local subcommand = args[1]
 
   if not subcommand then
-    vim.notify("Usage: :Necromancer <install|list|init> [args]", vim.log.levels.ERROR)
+    vim.notify("Usage: :Necromancer <install|list|status|init> [args]", vim.log.levels.ERROR)
     return
   end
 
@@ -330,11 +457,13 @@ local function dispatch(opts)
     M.cmd_install(subargs)
   elseif subcommand == "list" then
     M.cmd_list()
+  elseif subcommand == "status" then
+    M.cmd_status()
   elseif subcommand == "init" then
     M.cmd_init()
   else
     vim.notify("Unknown subcommand: " .. subcommand, vim.log.levels.ERROR)
-    vim.notify("Available commands: install, list, init", vim.log.levels.INFO)
+    vim.notify("Available commands: install, list, status, init", vim.log.levels.INFO)
   end
 end
 

--- a/lua/necromancer/commands.lua
+++ b/lua/necromancer/commands.lua
@@ -1,4 +1,5 @@
 local config = require("necromancer.core.config")
+local git = require("necromancer.core.git")
 local installer = require("necromancer.core.installer")
 local lockfile = require("necromancer.core.lockfile")
 local paths = require("necromancer.utils.paths")
@@ -16,6 +17,63 @@ local function find_plugin_by_name(plugins, name)
     end
   end
   return nil
+end
+
+---Get status of a single plugin
+---@param plugin_def table Plugin definition from config
+---@param install_dir string Installation directory
+---@param lock table Lock file data (unused for now)
+---@return table status {name, state, current_commit, config_commit, remote_commit, error_msg}
+function M.get_plugin_status(plugin_def, install_dir, lock)
+  local plugin_path = paths.resolve_plugin_path(plugin_def.name, install_dir)
+  local result = {
+    name = plugin_def.name,
+    state = "unknown",
+    config_commit = plugin_def.commit,
+    current_commit = nil,
+    remote_commit = nil,
+    error_msg = nil,
+  }
+
+  -- Check if directory exists
+  if vim.fn.isdirectory(plugin_path) ~= 1 then
+    result.state = "not_installed"
+    return result
+  end
+
+  -- Check if it's a git repo
+  if vim.fn.isdirectory(plugin_path .. "/.git") ~= 1 then
+    result.state = "corrupted"
+    return result
+  end
+
+  -- Get current commit
+  local ok, current_commit = pcall(git.get_current_commit, plugin_path)
+  if not ok then
+    result.state = "corrupted"
+    result.error_msg = tostring(current_commit)
+    return result
+  end
+  result.current_commit = current_commit
+
+  -- Fetch and get remote HEAD
+  local fetch_ok = pcall(git.fetch, plugin_path)
+  if fetch_ok then
+    result.remote_commit = git.get_remote_head(plugin_path)
+  else
+    result.error_msg = "fetch_failed"
+  end
+
+  -- Determine state
+  if current_commit ~= plugin_def.commit then
+    result.state = "outdated"
+  elseif result.remote_commit and result.remote_commit ~= plugin_def.commit then
+    result.state = "update_available"
+  else
+    result.state = "up_to_date"
+  end
+
+  return result
 end
 
 ---Install all plugins or a specific plugin

--- a/lua/necromancer/core/git.lua
+++ b/lua/necromancer/core/git.lua
@@ -90,4 +90,39 @@ function M.get_current_commit(repo_path)
   return result
 end
 
+---Get remote HEAD commit hash
+---@param repo_path string Path to repository
+---@return string|nil commit 40-character hash, or nil if no remote
+function M.get_remote_head(repo_path)
+  -- Try to get remote HEAD (origin/HEAD -> origin/main or origin/master)
+  local ok, result = pcall(function()
+    -- First try origin/HEAD
+    local head = git_exec({ "rev-parse", "origin/HEAD" }, repo_path)
+    return head
+  end)
+
+  if ok then
+    return result
+  end
+
+  -- Fallback: try origin/main, then origin/master
+  ok, result = pcall(function()
+    return git_exec({ "rev-parse", "origin/main" }, repo_path)
+  end)
+
+  if ok then
+    return result
+  end
+
+  ok, result = pcall(function()
+    return git_exec({ "rev-parse", "origin/master" }, repo_path)
+  end)
+
+  if ok then
+    return result
+  end
+
+  return nil
+end
+
 return M

--- a/tests/necromancer/commands_spec.lua
+++ b/tests/necromancer/commands_spec.lua
@@ -114,6 +114,103 @@ describe("commands", function()
     end)
   end)
 
+  describe("get_plugin_status", function()
+    local git = require("necromancer.core.git")
+
+    it("returns 'not_installed' when plugin directory does not exist", function()
+      local plugin_def = {
+        name = "test-plugin",
+        repo = "https://github.com/test/test-plugin",
+        commit = "1234567890abcdef1234567890abcdef12345678",
+      }
+      local install_dir = test_dir .. "/plugins"
+      local lock = { plugins = {} }
+
+      local status = commands.get_plugin_status(plugin_def, install_dir, lock)
+
+      assert.equals("test-plugin", status.name)
+      assert.equals("not_installed", status.state)
+    end)
+
+    it("returns 'corrupted' when directory exists but is not a git repo", function()
+      local plugin_def = {
+        name = "test-plugin",
+        repo = "https://github.com/test/test-plugin",
+        commit = "1234567890abcdef1234567890abcdef12345678",
+      }
+      local install_dir = test_dir .. "/plugins"
+      local lock = { plugins = {} }
+
+      -- Create directory without .git
+      vim.fn.mkdir(install_dir .. "/test-plugin", "p")
+
+      local status = commands.get_plugin_status(plugin_def, install_dir, lock)
+
+      assert.equals("test-plugin", status.name)
+      assert.equals("corrupted", status.state)
+    end)
+
+    it("returns 'outdated' when current commit differs from config", function()
+      local plugin_def = {
+        name = "test-plugin",
+        repo = test_dir .. "/origin-repo",
+        commit = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      }
+      local install_dir = test_dir .. "/plugins"
+      local lock = { plugins = {} }
+
+      -- Create origin repo
+      local origin_repo = test_dir .. "/origin-repo"
+      vim.fn.mkdir(origin_repo, "p")
+      vim.fn.system({ "git", "-C", origin_repo, "init" })
+      vim.fn.system({ "git", "-C", origin_repo, "config", "user.email", "test@test.com" })
+      vim.fn.system({ "git", "-C", origin_repo, "config", "user.name", "Test" })
+      vim.fn.writefile({ "test" }, origin_repo .. "/file.txt")
+      vim.fn.system({ "git", "-C", origin_repo, "add", "." })
+      vim.fn.system({ "git", "-C", origin_repo, "commit", "-m", "initial" })
+
+      -- Clone to install dir
+      vim.fn.mkdir(install_dir, "p")
+      git.clone(origin_repo, install_dir .. "/test-plugin")
+
+      local status = commands.get_plugin_status(plugin_def, install_dir, lock)
+
+      assert.equals("test-plugin", status.name)
+      assert.equals("outdated", status.state)
+    end)
+
+    it("returns 'up_to_date' when current commit matches config", function()
+      local origin_repo = test_dir .. "/origin-repo"
+      vim.fn.mkdir(origin_repo, "p")
+      vim.fn.system({ "git", "-C", origin_repo, "init" })
+      vim.fn.system({ "git", "-C", origin_repo, "config", "user.email", "test@test.com" })
+      vim.fn.system({ "git", "-C", origin_repo, "config", "user.name", "Test" })
+      vim.fn.writefile({ "test" }, origin_repo .. "/file.txt")
+      vim.fn.system({ "git", "-C", origin_repo, "add", "." })
+      vim.fn.system({ "git", "-C", origin_repo, "commit", "-m", "initial" })
+
+      local commit = git.get_current_commit(origin_repo)
+
+      local plugin_def = {
+        name = "test-plugin",
+        repo = origin_repo,
+        commit = commit,
+      }
+      local install_dir = test_dir .. "/plugins"
+      local lock = { plugins = {} }
+
+      -- Clone to install dir
+      vim.fn.mkdir(install_dir, "p")
+      git.clone(origin_repo, install_dir .. "/test-plugin")
+
+      local status = commands.get_plugin_status(plugin_def, install_dir, lock)
+
+      assert.equals("test-plugin", status.name)
+      assert.equals("up_to_date", status.state)
+      assert.equals(commit, status.current_commit)
+    end)
+  end)
+
   describe("cmd_install", function()
     it("shows error when config file not found", function()
       -- No config file exists

--- a/tests/necromancer/commands_spec.lua
+++ b/tests/necromancer/commands_spec.lua
@@ -211,6 +211,46 @@ describe("commands", function()
     end)
   end)
 
+  describe("cmd_status", function()
+    it("shows error when config file not found", function()
+      -- No config file exists
+      -- This should show an error but not crash
+      commands.cmd_status()
+      assert.is_true(true)
+    end)
+
+    it("opens floating window with status", function()
+      -- Create config with a plugin
+      local cfg = {
+        plugins = {
+          {
+            name = "plenary.nvim",
+            repo = "https://github.com/nvim-lua/plenary.nvim",
+            commit = "a3e3bc82a3f95c5ed0d7201546d5d2c19b20d683",
+          },
+        },
+      }
+      vim.fn.writefile({ vim.json.encode(cfg) }, ".necromancer.json")
+
+      -- Run status command
+      commands.cmd_status()
+
+      -- Find the floating window
+      local wins = vim.api.nvim_list_wins()
+      local found_float = false
+      for _, win in ipairs(wins) do
+        local win_config = vim.api.nvim_win_get_config(win)
+        if win_config.relative ~= "" then
+          found_float = true
+          vim.api.nvim_win_close(win, true)
+          break
+        end
+      end
+
+      assert.is_true(found_float, "Should open a floating window")
+    end)
+  end)
+
   describe("cmd_install", function()
     it("shows error when config file not found", function()
       -- No config file exists

--- a/tests/necromancer/core/git_spec.lua
+++ b/tests/necromancer/core/git_spec.lua
@@ -86,4 +86,23 @@ describe("git", function()
       end)
     end)
   end)
+
+  describe("get_remote_head", function()
+    it("returns remote HEAD commit hash", function()
+      -- Clone to get a repo with remote
+      local clone_path = test_dir .. "/cloned"
+      git.clone(test_repo, clone_path)
+
+      local remote_head = git.get_remote_head(clone_path)
+      assert.is_not_nil(remote_head)
+      assert.equals(40, #remote_head)
+      assert.is_true(remote_head:match("^[a-f0-9]+$") ~= nil)
+    end)
+
+    it("returns nil when remote does not exist", function()
+      -- test_repo has no remote
+      local remote_head = git.get_remote_head(test_repo)
+      assert.is_nil(remote_head)
+    end)
+  end)
 end)


### PR DESCRIPTION
## Summary

Add `:Necromancer status` command to display the status of all configured plugins. Shows whether each plugin is up-to-date, outdated, has updates available, is not installed, or is corrupted.

## Changes

- Add `git.get_remote_head()` function to get remote HEAD commit hash
- Add `get_plugin_status()` helper function for status determination
- Add `cmd_status()` command with floating window display
- Register `status` subcommand in dispatcher
- Fix test isolation using `NVIM_APPNAME` environment variable

## Test Plan

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed

## Checklist

- [x] Code follows synchronous-only architecture (no async/await, Promises, or callbacks)
- [x] No external runtime dependencies added (only Node.js built-ins)
- [x] Git commands quote paths and validate inputs
- [x] All tests pass (`make test-lua`)

## Related Issues

<!-- Link related issues: Fixes #123, Closes #456 -->