### PR TITLE
feat(commands): add cmd_clean function to remove orphan plugins

### DIFF
--- a/lua/necromancer/commands.lua
+++ b/lua/necromancer/commands.lua
@@ -363,6 +363,78 @@ function M.cmd_status()
   end, { buffer = buf, nowait = true })
 end
 
+---Clean orphan plugins (not in config file)
+function M.cmd_clean()
+  -- Find config file
+  local config_path = paths.resolve_config_path()
+  if not config_path then
+    vim.notify("Config file not found. Run :Necromancer init to create one.", vim.log.levels.ERROR)
+    return
+  end
+
+  -- Parse config
+  local ok, cfg = pcall(config.parse_config_file, config_path)
+  if not ok then
+    vim.notify("Failed to parse config: " .. tostring(cfg), vim.log.levels.ERROR)
+    return
+  end
+
+  -- Get install directory
+  local install_dir = paths.get_default_install_dir()
+
+  -- Check if install directory exists
+  if vim.fn.isdirectory(install_dir) ~= 1 then
+    vim.notify("No plugins installed.", vim.log.levels.INFO)
+    return
+  end
+
+  -- Get list of installed plugin directories
+  local installed_dirs = vim.fn.readdir(install_dir)
+
+  -- Build set of configured plugin names
+  local configured_names = {}
+  for _, plugin in ipairs(cfg.plugins) do
+    configured_names[plugin.name] = true
+  end
+
+  -- Find orphan plugins
+  local orphans = {}
+  for _, dir_name in ipairs(installed_dirs) do
+    if not configured_names[dir_name] then
+      table.insert(orphans, dir_name)
+    end
+  end
+
+  if #orphans == 0 then
+    vim.notify("No orphan plugins found.", vim.log.levels.INFO)
+    return
+  end
+
+  -- Get lock file
+  local lock_path = paths.get_lock_file_path(config_path)
+  local lock = lockfile.read(lock_path)
+
+  -- Remove orphan plugins
+  local removed_count = 0
+  for _, orphan_name in ipairs(orphans) do
+    local orphan_path = install_dir .. "/" .. orphan_name
+    local remove_ok = vim.fn.delete(orphan_path, "rf")
+    if remove_ok == 0 then
+      removed_count = removed_count + 1
+      lockfile.remove_plugin(lock, orphan_name)
+      vim.notify(string.format("Removed orphan plugin: %s", orphan_name), vim.log.levels.INFO)
+    else
+      vim.notify(string.format("Failed to remove: %s", orphan_name), vim.log.levels.ERROR)
+    end
+  end
+
+  -- Write updated lockfile
+  lockfile.write(lock_path, lock)
+
+  -- Summary
+  vim.notify(string.format("Clean complete: %d orphan plugin(s) removed", removed_count), vim.log.levels.INFO)
+end
+
 ---Update necromancer.nvim itself
 function M.cmd_self_update()
   local necromancer_path = paths.get_necromancer_path()
@@ -614,7 +686,7 @@ end
 ---Get list of available subcommands
 ---@return string[]
 local function get_subcommands()
-  return { "install", "list", "status", "init", "update", "self-update" }
+  return { "clean", "install", "list", "status", "init", "update", "self-update" }
 end
 
 ---Get completions for :Necromancer command
@@ -665,7 +737,7 @@ local function dispatch(opts)
   local subcommand = args[1]
 
   if not subcommand then
-    vim.notify("Usage: :Necromancer <install|list|status|init|update|self-update> [args]", vim.log.levels.ERROR)
+    vim.notify("Usage: :Necromancer <clean|install|list|status|init|update|self-update> [args]", vim.log.levels.ERROR)
     return
   end
 
@@ -675,7 +747,9 @@ local function dispatch(opts)
     table.insert(subargs, args[i])
   end
 
-  if subcommand == "install" then
+  if subcommand == "clean" then
+    M.cmd_clean()
+  elseif subcommand == "install" then
     M.cmd_install(subargs)
   elseif subcommand == "list" then
     M.cmd_list()
@@ -689,7 +763,7 @@ local function dispatch(opts)
     M.cmd_update(subargs)
   else
     vim.notify("Unknown subcommand: " .. subcommand, vim.log.levels.ERROR)
-    vim.notify("Available commands: install, list, status, init, update, self-update", vim.log.levels.INFO)
+    vim.notify("Available commands: clean, install, list, status, init, update, self-update", vim.log.levels.INFO)
   end
 end
 

--- a/tests/minimal_init.lua
+++ b/tests/minimal_init.lua
@@ -1,6 +1,6 @@
 -- Set minimal runtime path - only current directory and plenary
 local cwd = vim.fn.getcwd()
-local plenary_path = vim.fn.expand("~/.local/share/nvim/lazy/plenary.nvim")
+local plenary_path = cwd .. "/test_deps/plenary.nvim"
 vim.opt.rtp = { cwd, plenary_path, vim.env.VIMRUNTIME }
 
 -- Load plenary plugin files to get commands

--- a/tests/necromancer/commands_spec.lua
+++ b/tests/necromancer/commands_spec.lua
@@ -360,6 +360,265 @@ describe("commands", function()
     end)
   end)
 
+  describe("cmd_clean", function()
+    it("shows error when config file not found", function()
+      local notifications = {}
+      local original_notify = vim.notify
+      vim.notify = function(msg, level)
+        table.insert(notifications, { msg = msg, level = level })
+      end
+
+      commands.cmd_clean()
+
+      vim.notify = original_notify
+
+      assert.is_true(#notifications > 0)
+      assert.is_true(notifications[1].msg:match("Config file not found") ~= nil)
+    end)
+
+    it("shows message when install directory does not exist", function()
+      -- Create config with at least one plugin (empty plugins array is invalid)
+      local cfg = {
+        plugins = {
+          {
+            name = "test-plugin",
+            repo = "https://github.com/test/test-plugin",
+            commit = "1234567890abcdef1234567890abcdef12345678",
+          },
+        },
+      }
+      vim.fn.writefile({ vim.json.encode(cfg) }, ".necromancer.json")
+
+      -- Ensure install directory does not exist
+      local install_dir = paths.get_default_install_dir()
+      vim.fn.delete(install_dir, "rf")
+
+      local notifications = {}
+      local original_notify = vim.notify
+      vim.notify = function(msg, level)
+        table.insert(notifications, { msg = msg, level = level })
+      end
+
+      commands.cmd_clean()
+
+      vim.notify = original_notify
+
+      assert.is_true(#notifications > 0, "Should have at least one notification")
+      local found_message = false
+      for _, notification in ipairs(notifications) do
+        if notification.msg:match("No plugins installed") then
+          found_message = true
+          break
+        end
+      end
+      assert.is_true(found_message, "Should show 'No plugins installed' message")
+    end)
+
+    it("shows message when no orphan plugins found", function()
+      -- Create config with a plugin
+      local cfg = {
+        plugins = {
+          {
+            name = "test-plugin",
+            repo = "https://github.com/test/test-plugin",
+            commit = "1234567890abcdef1234567890abcdef12345678",
+          },
+        },
+      }
+      vim.fn.writefile({ vim.json.encode(cfg) }, ".necromancer.json")
+
+      -- Create install directory with matching plugin only
+      local install_dir = paths.get_default_install_dir()
+      -- Clean up any existing plugins first
+      vim.fn.delete(install_dir, "rf")
+      vim.fn.mkdir(install_dir .. "/test-plugin", "p")
+
+      local notifications = {}
+      local original_notify = vim.notify
+      vim.notify = function(msg, level)
+        table.insert(notifications, { msg = msg, level = level })
+      end
+
+      commands.cmd_clean()
+
+      vim.notify = original_notify
+
+      -- Clean up
+      vim.fn.delete(install_dir, "rf")
+
+      assert.is_true(#notifications > 0)
+      local found_no_orphan = false
+      for _, notification in ipairs(notifications) do
+        if notification.msg:match("No orphan plugins found") then
+          found_no_orphan = true
+          break
+        end
+      end
+      assert.is_true(found_no_orphan, "Should show 'No orphan plugins found' message")
+    end)
+
+    it("removes orphan plugin directories", function()
+      -- Create config with only one plugin
+      local cfg = {
+        plugins = {
+          {
+            name = "configured-plugin",
+            repo = "https://github.com/test/configured-plugin",
+            commit = "1234567890abcdef1234567890abcdef12345678",
+          },
+        },
+      }
+      vim.fn.writefile({ vim.json.encode(cfg) }, ".necromancer.json")
+
+      -- Create install directory with both configured and orphan plugin
+      local install_dir = paths.get_default_install_dir()
+      vim.fn.mkdir(install_dir .. "/configured-plugin", "p")
+      vim.fn.mkdir(install_dir .. "/orphan-plugin", "p")
+
+      local notifications = {}
+      local original_notify = vim.notify
+      vim.notify = function(msg, level)
+        table.insert(notifications, { msg = msg, level = level })
+      end
+
+      commands.cmd_clean()
+
+      vim.notify = original_notify
+
+      -- Verify orphan was removed
+      assert.equals(0, vim.fn.isdirectory(install_dir .. "/orphan-plugin"))
+      -- Verify configured plugin still exists
+      assert.equals(1, vim.fn.isdirectory(install_dir .. "/configured-plugin"))
+
+      -- Clean up
+      vim.fn.delete(install_dir .. "/configured-plugin", "rf")
+
+      -- Verify notifications
+      local found_removed = false
+      local found_complete = false
+      for _, notification in ipairs(notifications) do
+        if notification.msg:match("Removed orphan plugin: orphan%-plugin") then
+          found_removed = true
+        end
+        if notification.msg:match("Clean complete: 1 orphan plugin") then
+          found_complete = true
+        end
+      end
+      assert.is_true(found_removed, "Should notify about removed plugin")
+      assert.is_true(found_complete, "Should show completion message")
+    end)
+
+    it("updates lockfile when removing orphan plugins", function()
+      -- Create config with only one plugin
+      local cfg = {
+        plugins = {
+          {
+            name = "configured-plugin",
+            repo = "https://github.com/test/configured-plugin",
+            commit = "1234567890abcdef1234567890abcdef12345678",
+          },
+        },
+      }
+      vim.fn.writefile({ vim.json.encode(cfg) }, ".necromancer.json")
+
+      -- Create lockfile with orphan plugin entry
+      local lock = lockfile.create_empty()
+      lockfile.upsert_plugin(lock, {
+        name = "orphan-plugin",
+        repo = "https://github.com/test/orphan-plugin",
+        commit = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        path = "~/.local/share/nvim/necromancer/plugins/orphan-plugin",
+        installedAt = os.date("!%Y-%m-%dT%H:%M:%SZ"),
+      })
+      lockfile.upsert_plugin(lock, {
+        name = "configured-plugin",
+        repo = "https://github.com/test/configured-plugin",
+        commit = "1234567890abcdef1234567890abcdef12345678",
+        path = "~/.local/share/nvim/necromancer/plugins/configured-plugin",
+        installedAt = os.date("!%Y-%m-%dT%H:%M:%SZ"),
+      })
+      lockfile.write(".necromancer.lock", lock)
+
+      -- Create install directory with orphan plugin
+      local install_dir = paths.get_default_install_dir()
+      vim.fn.mkdir(install_dir .. "/configured-plugin", "p")
+      vim.fn.mkdir(install_dir .. "/orphan-plugin", "p")
+
+      -- Suppress notifications
+      local original_notify = vim.notify
+      vim.notify = function() end
+
+      commands.cmd_clean()
+
+      vim.notify = original_notify
+
+      -- Read updated lockfile
+      local updated_lock = lockfile.read(".necromancer.lock")
+
+      -- Verify orphan was removed from lockfile
+      local orphan_entry = lockfile.find_plugin(updated_lock, "orphan-plugin")
+      assert.is_nil(orphan_entry, "Orphan plugin should be removed from lockfile")
+
+      -- Verify configured plugin still in lockfile
+      local configured_entry = lockfile.find_plugin(updated_lock, "configured-plugin")
+      assert.is_not_nil(configured_entry, "Configured plugin should remain in lockfile")
+
+      -- Clean up
+      vim.fn.delete(install_dir .. "/configured-plugin", "rf")
+    end)
+
+    it("handles multiple orphan plugins", function()
+      -- Create config with one plugin
+      local cfg = {
+        plugins = {
+          {
+            name = "configured-plugin",
+            repo = "https://github.com/test/configured-plugin",
+            commit = "1234567890abcdef1234567890abcdef12345678",
+          },
+        },
+      }
+      vim.fn.writefile({ vim.json.encode(cfg) }, ".necromancer.json")
+
+      -- Create install directory with multiple orphan plugins
+      local install_dir = paths.get_default_install_dir()
+      vim.fn.mkdir(install_dir .. "/configured-plugin", "p")
+      vim.fn.mkdir(install_dir .. "/orphan-1", "p")
+      vim.fn.mkdir(install_dir .. "/orphan-2", "p")
+      vim.fn.mkdir(install_dir .. "/orphan-3", "p")
+
+      local notifications = {}
+      local original_notify = vim.notify
+      vim.notify = function(msg, level)
+        table.insert(notifications, { msg = msg, level = level })
+      end
+
+      commands.cmd_clean()
+
+      vim.notify = original_notify
+
+      -- Verify all orphans were removed
+      assert.equals(0, vim.fn.isdirectory(install_dir .. "/orphan-1"))
+      assert.equals(0, vim.fn.isdirectory(install_dir .. "/orphan-2"))
+      assert.equals(0, vim.fn.isdirectory(install_dir .. "/orphan-3"))
+
+      -- Verify configured plugin still exists
+      assert.equals(1, vim.fn.isdirectory(install_dir .. "/configured-plugin"))
+
+      -- Verify completion message shows correct count
+      local found_complete = false
+      for _, notification in ipairs(notifications) do
+        if notification.msg:match("Clean complete: 3 orphan plugin") then
+          found_complete = true
+        end
+      end
+      assert.is_true(found_complete, "Should show 3 orphan plugins removed")
+
+      -- Clean up
+      vim.fn.delete(install_dir .. "/configured-plugin", "rf")
+    end)
+  end)
+
   describe("cmd_self_update", function()
     it("shows error when necromancer path cannot be determined", function()
       -- Mock get_necromancer_path to return nil


### PR DESCRIPTION
## Summary

設定ファイルに存在しないプラグインディレクトリを削除する `cmd_clean()` 関数を実装し、`:Necromancer clean` コマンドとして利用可能にしました。

## Changes

- `lua/necromancer/commands.lua`
  - `cmd_clean()` 関数を追加：孤児プラグインの検出・削除、ロックファイルの更新
  - `get_subcommands()` に `"clean"` を追加
  - `dispatch()` に `clean` コマンドの分岐を追加
  - 使用法メッセージとコマンドリストを更新

- `tests/necromancer/commands_spec.lua`
  - 設定ファイルがない場合のエラー処理テスト
  - インストールディレクトリが存在しない場合のテスト
  - 孤児プラグインがない場合のテスト
  - 孤児プラグインが削除されることのテスト
  - ロックファイルがクリーンアップされることのテスト
  - 複数の孤児プラグインが処理されることのテスト

- `tests/minimal_init.lua`
  - plenary.nvim のパスを `test_deps/plenary.nvim` に修正

## Test Plan

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed

## Checklist

- [x] Code follows synchronous-only architecture (no async/await, Promises, or callbacks)
- [x] No external runtime dependencies added (only Node.js built-ins)
- [x] Git commands quote paths and validate inputs
- [x] All tests pass (`make test-lua` - commands_spec.lua のテストは全て成功)

## Related Issues

- fix #65