### PR TITLE
feat: support global config_path and install_dir in setup options

### DIFF
--- a/docs/plans/2026-01-25-global-config-path-design.md
+++ b/docs/plans/2026-01-25-global-config-path-design.md
@@ -1,0 +1,93 @@
+# グローバル設定パス対応設計
+
+## 概要
+
+`:Necromancer` コマンドを任意のディレクトリから実行可能にする。現状ではカレントディレクトリに `.necromancer.json` が存在しないと動作しない。
+
+## 背景
+
+現在の `paths.resolve_config_path()` は以下の順序で設定ファイルを検索する：
+1. カレントディレクトリの `.necromancer.json`
+2. グローバル設定 `~/.config/necromancer/config.json`
+
+`setup()` には `config_path` オプションがあるが、コマンド側で参照されていないため機能していない。
+
+## 設計
+
+### 1. モジュールレベル変数で設定を保持
+
+`lua/necromancer/init.lua` に `_config` テーブルを追加：
+
+```lua
+M._config = {
+  config_path = nil,  -- setup() で指定された設定ファイルパス
+  install_dir = nil,  -- setup() で指定されたインストールディレクトリ
+}
+```
+
+`setup()` で設定を保存：
+
+```lua
+function M.setup(opts)
+  opts = opts or {}
+  M._config.config_path = opts.config_path
+  M._config.install_dir = opts.install_dir
+  -- 以降は既存ロジック...
+end
+```
+
+### 2. commands.lua からの参照
+
+ファイル冒頭で `necromancer` モジュールを require：
+
+```lua
+local necromancer = require("necromancer")
+```
+
+各コマンドで保存された設定を参照：
+
+```lua
+-- config_path
+local config_path = paths.resolve_config_path(necromancer._config.config_path)
+
+-- install_dir
+local install_dir = necromancer._config.install_dir or paths.get_default_install_dir()
+```
+
+### 3. 影響を受けるコマンド
+
+**config_path を参照:**
+- `cmd_install`
+- `cmd_list`
+- `cmd_status`
+- `cmd_clean`
+- `cmd_update`
+- `complete`（補完関数）
+
+**install_dir を参照:**
+- `cmd_install`
+- `cmd_status`
+- `cmd_clean`
+- `cmd_update`
+
+**影響なし:**
+- `cmd_init` - 常にカレントディレクトリに作成（意図的）
+- `cmd_self_update` - necromancer.nvim 自身のパスを使用
+
+## 使用例
+
+```lua
+require("necromancer").setup({
+  config_path = "~/.config/nvim/.necromancer.json",
+  -- install_dir は省略可能（デフォルト使用）
+})
+```
+
+## 設計の根拠
+
+### モジュールレベル変数を選択した理由
+
+1. **責務の明確さ** - `paths.lua` はパスの解決・変換のみを担当し、状態を持たない
+2. **Neovim プラグインの慣習** - 多くのプラグインが `M.config` パターンを採用
+3. **テストしやすさ** - `paths.lua` が純粋関数のままでテストが容易
+4. **依存関係のシンプルさ** - `init.lua` が設定の中心となる

--- a/lua/necromancer/commands.lua
+++ b/lua/necromancer/commands.lua
@@ -103,7 +103,7 @@ function M.cmd_install(args)
   end
 
   -- Get install directory
-  local install_dir = paths.get_default_install_dir()
+  local install_dir = necromancer._config.install_dir or paths.get_default_install_dir()
 
   -- Ensure install directory exists
   vim.fn.mkdir(install_dir, "p")
@@ -264,7 +264,7 @@ function M.cmd_status()
   end
 
   -- Get install directory and lock file
-  local install_dir = paths.get_default_install_dir()
+  local install_dir = necromancer._config.install_dir or paths.get_default_install_dir()
   local lock_path = paths.get_lock_file_path(config_path)
   local lock = lockfile.read(lock_path)
 
@@ -381,7 +381,7 @@ function M.cmd_clean()
   end
 
   -- Get install directory
-  local install_dir = paths.get_default_install_dir()
+  local install_dir = necromancer._config.install_dir or paths.get_default_install_dir()
 
   -- Check if install directory exists
   if vim.fn.isdirectory(install_dir) ~= 1 then
@@ -542,7 +542,7 @@ function M.cmd_update(args)
   end
 
   -- Get install directory
-  local install_dir = paths.get_default_install_dir()
+  local install_dir = necromancer._config.install_dir or paths.get_default_install_dir()
 
   -- Determine which plugins to update
   local plugins_to_update = {}

--- a/lua/necromancer/commands.lua
+++ b/lua/necromancer/commands.lua
@@ -2,6 +2,7 @@ local config = require("necromancer.core.config")
 local git = require("necromancer.core.git")
 local installer = require("necromancer.core.installer")
 local lockfile = require("necromancer.core.lockfile")
+local necromancer = require("necromancer")
 local paths = require("necromancer.utils.paths")
 local validator = require("necromancer.core.validator")
 
@@ -88,7 +89,7 @@ function M.cmd_install(args)
   local plugin_name = args[1]
 
   -- Find config file
-  local config_path = paths.resolve_config_path()
+  local config_path = paths.resolve_config_path(necromancer._config.config_path)
   if not config_path then
     vim.notify("Config file not found. Run :Necromancer init to create one.", vim.log.levels.ERROR)
     return
@@ -176,7 +177,7 @@ end
 ---List installed plugins
 function M.cmd_list()
   -- Find config file
-  local config_path = paths.resolve_config_path()
+  local config_path = paths.resolve_config_path(necromancer._config.config_path)
   if not config_path then
     vim.notify("Config file not found. Run :Necromancer init to create one.", vim.log.levels.WARN)
     return
@@ -249,7 +250,7 @@ local STATUS_INFO = {
 ---Show status of all configured plugins
 function M.cmd_status()
   -- Find config file
-  local config_path = paths.resolve_config_path()
+  local config_path = paths.resolve_config_path(necromancer._config.config_path)
   if not config_path then
     vim.notify("Config file not found. Run :Necromancer init to create one.", vim.log.levels.ERROR)
     return
@@ -366,7 +367,7 @@ end
 ---Clean orphan plugins (not in config file)
 function M.cmd_clean()
   -- Find config file
-  local config_path = paths.resolve_config_path()
+  local config_path = paths.resolve_config_path(necromancer._config.config_path)
   if not config_path then
     vim.notify("Config file not found. Run :Necromancer init to create one.", vim.log.levels.ERROR)
     return
@@ -527,7 +528,7 @@ function M.cmd_update(args)
   local plugin_name = args[1]
 
   -- Find config file
-  local config_path = paths.resolve_config_path()
+  local config_path = paths.resolve_config_path(necromancer._config.config_path)
   if not config_path then
     vim.notify("Config file not found. Run :Necromancer init to create one.", vim.log.levels.ERROR)
     return
@@ -708,7 +709,7 @@ local function complete(arg_lead, cmd_line, cursor_pos)
 
   -- Second argument for install or update: plugin names
   if num_args == 3 and (parts[2] == "install" or parts[2] == "update") then
-    local config_path = paths.resolve_config_path()
+    local config_path = paths.resolve_config_path(necromancer._config.config_path)
     if not config_path then
       return {}
     end

--- a/lua/necromancer/init.lua
+++ b/lua/necromancer/init.lua
@@ -2,6 +2,11 @@ local M = {}
 
 M._VERSION = "2.0.0"
 
+M._config = {
+  config_path = nil,
+  install_dir = nil,
+}
+
 ---Setup necromancer plugin manager
 ---@param opts? table Optional configuration
 ---  - config_path: string|nil - Custom path to config file
@@ -12,6 +17,10 @@ M._VERSION = "2.0.0"
 ---    - quiet: boolean (default: false) - Suppress debug messages
 function M.setup(opts)
   opts = opts or {}
+
+  -- Save config options
+  M._config.config_path = opts.config_path
+  M._config.install_dir = opts.install_dir
 
   local paths = require("necromancer.utils.paths")
   local lockfile = require("necromancer.core.lockfile")

--- a/tests/necromancer/commands_spec.lua
+++ b/tests/necromancer/commands_spec.lua
@@ -654,6 +654,75 @@ describe("commands", function()
   end)
 end)
 
+describe("commands with custom install_dir", function()
+  local test_dir
+  local custom_install_dir
+  local original_cwd
+
+  before_each(function()
+    original_cwd = vim.fn.getcwd()
+
+    test_dir = vim.fn.tempname()
+    custom_install_dir = vim.fn.tempname() .. "/custom-plugins"
+    vim.fn.mkdir(test_dir, "p")
+    vim.fn.mkdir(custom_install_dir, "p")
+
+    -- 設定ファイルを作成
+    local cfg = {
+      plugins = {
+        {
+          name = "test-plugin",
+          repo = "https://github.com/test/test-plugin",
+          commit = "1234567890abcdef1234567890abcdef12345678",
+        },
+      },
+    }
+    vim.fn.writefile({ vim.json.encode(cfg) }, test_dir .. "/.necromancer.json")
+  end)
+
+  after_each(function()
+    vim.fn.chdir(original_cwd)
+    vim.fn.delete(test_dir, "rf")
+    vim.fn.delete(custom_install_dir, "rf")
+    pcall(vim.api.nvim_del_user_command, "Necromancer")
+    package.loaded["necromancer"] = nil
+    package.loaded["necromancer.commands"] = nil
+    package.loaded["necromancer.init"] = nil
+  end)
+
+  it("cmd_clean uses install_dir from setup", function()
+    package.loaded["necromancer"] = nil
+    package.loaded["necromancer.commands"] = nil
+    package.loaded["necromancer.init"] = nil
+
+    local necromancer_mod = require("necromancer")
+    necromancer_mod.setup({ install_dir = custom_install_dir })
+
+    local commands_module = require("necromancer.commands")
+
+    -- カスタム install_dir にプラグインディレクトリを作成
+    vim.fn.mkdir(custom_install_dir .. "/test-plugin", "p")
+    vim.fn.mkdir(custom_install_dir .. "/orphan-plugin", "p")
+
+    -- test_dir に移動（設定ファイルがある場所）
+    vim.fn.chdir(test_dir)
+
+    local notifications = {}
+    local original_notify = vim.notify
+    vim.notify = function(msg, level)
+      table.insert(notifications, { msg = msg, level = level })
+    end
+
+    commands_module.cmd_clean()
+
+    vim.notify = original_notify
+
+    -- orphan が削除されたことを確認
+    assert.equals(0, vim.fn.isdirectory(custom_install_dir .. "/orphan-plugin"))
+    assert.equals(1, vim.fn.isdirectory(custom_install_dir .. "/test-plugin"))
+  end)
+end)
+
 describe("commands with custom config_path", function()
   local test_dir
   local config_dir

--- a/tests/necromancer/commands_spec.lua
+++ b/tests/necromancer/commands_spec.lua
@@ -653,3 +653,87 @@ describe("commands", function()
     end)
   end)
 end)
+
+describe("commands with custom config_path", function()
+  local test_dir
+  local config_dir
+  local original_cwd
+
+  before_each(function()
+    -- Save current directory
+    original_cwd = vim.fn.getcwd()
+
+    -- テストディレクトリを作成
+    test_dir = vim.fn.tempname()
+    config_dir = vim.fn.tempname()
+    vim.fn.mkdir(test_dir, "p")
+    vim.fn.mkdir(config_dir, "p")
+
+    -- 設定ファイルを config_dir に作成
+    local cfg = {
+      plugins = {
+        {
+          name = "test-plugin",
+          repo = "https://github.com/test/test-plugin",
+          commit = "1234567890abcdef1234567890abcdef12345678",
+        },
+      },
+    }
+    vim.fn.writefile({ vim.json.encode(cfg) }, config_dir .. "/.necromancer.json")
+  end)
+
+  after_each(function()
+    vim.fn.chdir(original_cwd)
+    vim.fn.delete(test_dir, "rf")
+    vim.fn.delete(config_dir, "rf")
+    pcall(vim.api.nvim_del_user_command, "Necromancer")
+    -- モジュールキャッシュをクリア
+    package.loaded["necromancer"] = nil
+    package.loaded["necromancer.commands"] = nil
+    package.loaded["necromancer.init"] = nil
+  end)
+
+  it("cmd_list uses config_path from setup", function()
+    -- モジュールキャッシュをクリアしてリロード
+    package.loaded["necromancer"] = nil
+    package.loaded["necromancer.commands"] = nil
+    package.loaded["necromancer.init"] = nil
+
+    -- カスタム config_path で setup
+    local necromancer = require("necromancer")
+    necromancer.setup({ config_path = config_dir .. "/.necromancer.json" })
+
+    local commands_module = require("necromancer.commands")
+    local lockfile_module = require("necromancer.core.lockfile")
+
+    -- ロックファイルを作成
+    local lock = lockfile_module.create_empty()
+    lockfile_module.upsert_plugin(lock, {
+      name = "test-plugin",
+      repo = "https://github.com/test/test-plugin",
+      commit = "1234567890abcdef1234567890abcdef12345678",
+      path = "~/.local/share/nvim/necromancer/plugins/test-plugin",
+      installedAt = os.date("!%Y-%m-%dT%H:%M:%SZ"),
+    })
+    lockfile_module.write(config_dir .. "/.necromancer.lock", lock)
+
+    -- test_dir に移動（設定ファイルがない場所）
+    vim.fn.chdir(test_dir)
+
+    -- cmd_list を実行（カレントディレクトリに設定ファイルがなくても動作する）
+    commands_module.cmd_list()
+
+    -- フローティングウィンドウが開くことを確認
+    local wins = vim.api.nvim_list_wins()
+    local found_float = false
+    for _, win in ipairs(wins) do
+      local win_config = vim.api.nvim_win_get_config(win)
+      if win_config.relative ~= "" then
+        found_float = true
+        vim.api.nvim_win_close(win, true)
+        break
+      end
+    end
+    assert.is_true(found_float, "Should find config from setup and open floating window")
+  end)
+end)

--- a/tests/necromancer/init_spec.lua
+++ b/tests/necromancer/init_spec.lua
@@ -1,0 +1,46 @@
+describe("necromancer", function()
+  local necromancer
+
+  before_each(function()
+    -- モジュールキャッシュをクリア
+    package.loaded["necromancer"] = nil
+    package.loaded["necromancer.commands"] = nil
+    necromancer = require("necromancer")
+  end)
+
+  after_each(function()
+    pcall(vim.api.nvim_del_user_command, "Necromancer")
+  end)
+
+  describe("_config", function()
+    it("has _config table", function()
+      assert.is_table(necromancer._config)
+    end)
+
+    it("has config_path field initialized to nil", function()
+      assert.is_nil(necromancer._config.config_path)
+    end)
+
+    it("has install_dir field initialized to nil", function()
+      assert.is_nil(necromancer._config.install_dir)
+    end)
+  end)
+
+  describe("setup", function()
+    it("saves config_path to _config", function()
+      necromancer.setup({ config_path = "~/.config/nvim/.necromancer.json" })
+      assert.equals("~/.config/nvim/.necromancer.json", necromancer._config.config_path)
+    end)
+
+    it("saves install_dir to _config", function()
+      necromancer.setup({ install_dir = "/custom/path" })
+      assert.equals("/custom/path", necromancer._config.install_dir)
+    end)
+
+    it("keeps nil when options not provided", function()
+      necromancer.setup({})
+      assert.is_nil(necromancer._config.config_path)
+      assert.is_nil(necromancer._config.install_dir)
+    end)
+  end)
+end)


### PR DESCRIPTION
## Summary

- `setup()` で指定した `config_path` と `install_dir` をコマンドから参照可能にする
- `init.lua` に `_config` テーブルを追加し、`setup()` で設定を保存
- `commands.lua` の各コマンドで `_config` の値を使用

## Changes

- `lua/necromancer/init.lua`: `_config` テーブルを追加、`setup()` で `config_path` と `install_dir` を保存
- `lua/necromancer/commands.lua`: 各コマンドで `necromancer._config.config_path` と `necromancer._config.install_dir` を参照
- `tests/necromancer/init_spec.lua`: `_config` テーブルと `setup()` のテストを追加
- `tests/necromancer/commands_spec.lua`: カスタム `config_path` と `install_dir` のテストを追加

## Test Plan

- [x] `make test-lua` で全テストがパス
- [ ] 手動テスト: `setup({ config_path = "~/.config/nvim/.necromancer.json" })` で任意のディレクトリから `:Necromancer list` が動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)