### PR TITLE
feat(json): add pretty print for JSON output files

### DIFF
--- a/lua/necromancer/commands.lua
+++ b/lua/necromancer/commands.lua
@@ -1,6 +1,7 @@
 local config = require("necromancer.core.config")
 local git = require("necromancer.core.git")
 local installer = require("necromancer.core.installer")
+local json = require("necromancer.utils.json")
 local lockfile = require("necromancer.core.lockfile")
 local necromancer = require("necromancer")
 local paths = require("necromancer.utils.paths")
@@ -511,9 +512,10 @@ function M.cmd_init()
     },
   }
 
-  -- Write config file with pretty formatting using vim.json
-  local json = vim.json.encode(default_config)
-  vim.fn.writefile({ json }, config_path)
+  -- Write config file with pretty formatting
+  local json_str = json.encode_pretty(default_config)
+  local lines = vim.split(json_str, "\n", { plain = true })
+  vim.fn.writefile(lines, config_path)
   vim.notify("Created config file: " .. config_path, vim.log.levels.INFO)
 end
 

--- a/lua/necromancer/core/config.lua
+++ b/lua/necromancer/core/config.lua
@@ -1,4 +1,5 @@
 local errors = require("necromancer.utils.errors")
+local json = require("necromancer.utils.json")
 local validator = require("necromancer.core.validator")
 local dependencies = require("necromancer.core.dependencies")
 
@@ -155,8 +156,9 @@ function M.update_plugins_commits(config_path, updates)
   end
 
   -- Write back
-  local json = vim.json.encode(cfg)
-  vim.fn.writefile({ json }, config_path)
+  local json_str = json.encode_pretty(cfg)
+  local lines = vim.split(json_str, "\n", { plain = true })
+  vim.fn.writefile(lines, config_path)
 end
 
 return M

--- a/lua/necromancer/core/lockfile.lua
+++ b/lua/necromancer/core/lockfile.lua
@@ -1,3 +1,5 @@
+local json = require("necromancer.utils.json")
+
 local M = {}
 
 M.LOCK_FILE_VERSION = "1"
@@ -39,8 +41,9 @@ end
 ---@param data table
 function M.write(path, data)
   data.generated = os.date("!%Y-%m-%dT%H:%M:%SZ")
-  local json = vim.json.encode(data)
-  vim.fn.writefile({ json }, path)
+  local json_str = json.encode_pretty(data)
+  local lines = vim.split(json_str, "\n", { plain = true })
+  vim.fn.writefile(lines, path)
 end
 
 ---Find plugin in lock file

--- a/lua/necromancer/utils/json.lua
+++ b/lua/necromancer/utils/json.lua
@@ -1,0 +1,120 @@
+local M = {}
+
+---Pretty print JSON with indentation (2 spaces)
+---Works with Neovim 0.9+ (doesn't rely on vim.json.encode options)
+---@param value any Value to encode
+---@param indent_size? number Indent size (default: 2)
+---@return string json Pretty-printed JSON string
+function M.encode_pretty(value, indent_size)
+  indent_size = indent_size or 2
+
+  local function encode(val, level)
+    local indent = string.rep(" ", level * indent_size)
+    local next_indent = string.rep(" ", (level + 1) * indent_size)
+    local t = type(val)
+
+    if val == vim.NIL then
+      return "null"
+    elseif t == "nil" then
+      return "null"
+    elseif t == "boolean" then
+      return val and "true" or "false"
+    elseif t == "number" then
+      if val ~= val then -- NaN
+        return "null"
+      elseif val == math.huge then
+        return "null"
+      elseif val == -math.huge then
+        return "null"
+      else
+        return tostring(val)
+      end
+    elseif t == "string" then
+      -- Escape special characters
+      local escaped = val:gsub('[\\"]', {
+        ["\\"] = "\\\\",
+        ['"'] = '\\"',
+      })
+      -- Escape control characters (0x00-0x1f)
+      escaped = escaped:gsub("%c", function(c)
+        local byte = string.byte(c)
+        if byte == 8 then -- backspace
+          return "\\b"
+        elseif byte == 9 then -- tab
+          return "\\t"
+        elseif byte == 10 then -- newline
+          return "\\n"
+        elseif byte == 12 then -- form feed
+          return "\\f"
+        elseif byte == 13 then -- carriage return
+          return "\\r"
+        else
+          return string.format("\\u%04x", byte)
+        end
+      end)
+      return '"' .. escaped .. '"'
+    elseif t == "table" then
+      -- Check if array (sequential integer keys starting from 1)
+      local is_array = true
+      local max_index = 0
+      for k, _ in pairs(val) do
+        if type(k) ~= "number" or k ~= math.floor(k) or k < 1 then
+          is_array = false
+          break
+        end
+        if k > max_index then
+          max_index = k
+        end
+      end
+      -- Verify no gaps
+      if is_array and max_index > 0 then
+        for i = 1, max_index do
+          if val[i] == nil then
+            is_array = false
+            break
+          end
+        end
+      end
+      -- Empty table is array
+      if next(val) == nil then
+        is_array = true
+      end
+
+      if is_array then
+        if max_index == 0 then
+          return "[]"
+        end
+        local parts = {}
+        for i = 1, max_index do
+          table.insert(parts, next_indent .. encode(val[i], level + 1))
+        end
+        return "[\n" .. table.concat(parts, ",\n") .. "\n" .. indent .. "]"
+      else
+        -- Object
+        local keys = {}
+        for k, _ in pairs(val) do
+          if type(k) == "string" then
+            table.insert(keys, k)
+          end
+        end
+        if #keys == 0 then
+          return "{}"
+        end
+        -- Sort keys for consistent output
+        table.sort(keys)
+        local parts = {}
+        for _, k in ipairs(keys) do
+          local v = val[k]
+          table.insert(parts, next_indent .. encode(k, level + 1) .. ": " .. encode(v, level + 1))
+        end
+        return "{\n" .. table.concat(parts, ",\n") .. "\n" .. indent .. "}"
+      end
+    else
+      error("Cannot encode type: " .. t)
+    end
+  end
+
+  return encode(value, 0)
+end
+
+return M

--- a/tests/necromancer/utils/json_spec.lua
+++ b/tests/necromancer/utils/json_spec.lua
@@ -1,0 +1,80 @@
+local json = require("necromancer.utils.json")
+
+describe("json", function()
+  describe("encode_pretty", function()
+    it("encodes empty object", function()
+      local result = json.encode_pretty({})
+      assert.equals("[]", result)
+    end)
+
+    it("encodes empty array explicitly", function()
+      local result = json.encode_pretty({ plugins = {} })
+      assert.equals('{\n  "plugins": []\n}', result)
+    end)
+
+    it("encodes simple object with indentation", function()
+      local result = json.encode_pretty({ name = "test" })
+      assert.equals('{\n  "name": "test"\n}', result)
+    end)
+
+    it("encodes array with indentation", function()
+      local result = json.encode_pretty({ 1, 2, 3 })
+      assert.equals("[\n  1,\n  2,\n  3\n]", result)
+    end)
+
+    it("encodes nested structure", function()
+      local data = {
+        plugins = {
+          { name = "foo", commit = "abc123" },
+        },
+      }
+      local result = json.encode_pretty(data)
+      -- Check it contains proper indentation
+      assert.is_true(result:find('  "plugins"') ~= nil)
+      assert.is_true(result:find('    {') ~= nil)
+      assert.is_true(result:find('      "commit"') ~= nil)
+    end)
+
+    it("encodes strings with special characters", function()
+      local result = json.encode_pretty({ text = 'hello\nworld\t"test"' })
+      assert.is_true(result:find('\\n') ~= nil)
+      assert.is_true(result:find('\\t') ~= nil)
+      assert.is_true(result:find('\\"') ~= nil)
+    end)
+
+    it("encodes boolean values", function()
+      local result = json.encode_pretty({ enabled = true, disabled = false })
+      assert.is_true(result:find("true") ~= nil)
+      assert.is_true(result:find("false") ~= nil)
+    end)
+
+    it("encodes nil as null", function()
+      local result = json.encode_pretty({ value = vim.NIL })
+      assert.is_true(result:find("null") ~= nil)
+    end)
+
+    it("sorts object keys", function()
+      local data = { z = 1, a = 2, m = 3 }
+      local result = json.encode_pretty(data)
+      local a_pos = result:find('"a"')
+      local m_pos = result:find('"m"')
+      local z_pos = result:find('"z"')
+      assert.is_true(a_pos < m_pos)
+      assert.is_true(m_pos < z_pos)
+    end)
+
+    it("produces valid JSON that can be decoded", function()
+      local data = {
+        version = "1",
+        plugins = {
+          { name = "test", repo = "https://github.com/test/test", commit = "abc123" },
+        },
+      }
+      local json_str = json.encode_pretty(data)
+      local decoded = vim.json.decode(json_str)
+      assert.equals(data.version, decoded.version)
+      assert.equals(1, #decoded.plugins)
+      assert.equals("test", decoded.plugins[1].name)
+    end)
+  end)
+end)


### PR DESCRIPTION
## Summary
- :Necromancer コマンド実行時に `.necromancer.json` と `.necromancer.lock` のインデントが崩れる問題を修正
- 2スペースインデントでJSONを整形出力する `json.encode_pretty()` ユーティリティを追加
- Neovim 0.9+ 互換（`vim.json.encode` のオプションに依存しない）

## Test plan
- [x] `make test-file FILE=tests/necromancer/utils/json_spec.lua` でjsonユーティリティのテストが通ること
- [x] `make test-file FILE=tests/necromancer/core/lockfile_spec.lua` でlockfileテストが通ること
- [x] `make test-file FILE=tests/necromancer/core/config_spec.lua` でconfigテストが通ること
- [ ] `:Necromancer init` で整形されたJSONが出力されること
- [ ] `:Necromancer install` で整形されたlockファイルが出力されること
- [ ] `:Necromancer update` で整形されたJSONが出力されること
- [ ] `:Necromancer clean` で整形されたlockファイルが出力されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)